### PR TITLE
Add Auto-Off States

### DIFF
--- a/examples/output/backtrack_example.thyo
+++ b/examples/output/backtrack_example.thyo
@@ -1,0 +1,36 @@
+
+name : backtrack
+default case : /at
+
+====
+
+# no classes/states?
+
+====
+
+# Vowels
+e : e
+o : o
+u : u
+i : i
+a : a
+ough : o u g h
+aw : a w
+
+# consonants
+t  : t
+d  : d
+k  : k
+g  : g
+m  : m
+n  : n
+ng : n g
+s  : s
+l  : l
+r  : r
+w  : w
+p  : p
+b  : b
+f  : f
+v  : v
+h  : h

--- a/examples/output/backtrack_example2.thyo
+++ b/examples/output/backtrack_example2.thyo
@@ -1,0 +1,41 @@
+
+name : backtrack2
+default case : /at
+
+# Alternate version to show
+# whether the text is passing
+# through or being interpreted properly.
+
+====
+
+# no classes/states?
+
+====
+
+# Vowels
+e : ε
+o : ο
+u : υ
+i : ι
+a : α
+ough : α ω 
+aw : ω
+
+# consonants
+t  : τ
+d  : δ
+k  : κ
+g  : γ
+m  : μ
+n  : ν
+ng : γ γ
+s  : σ 
+s  : ς $
+l  : λ
+r  : ρ
+w  : ϋ
+p  : π
+b  : β
+f  : φ
+v  : ζ # there's probably a better choice for this...
+h  : χ

--- a/examples/output/kwakwala_grubb.thyo
+++ b/examples/output/kwakwala_grubb.thyo
@@ -65,13 +65,13 @@ a     : a
 e     : e h
 i     : i
 o     : o
-u     : y
+u     : u
 schwa : e
 
 ^ glt a     : a
 ^ glt e     : e h
 ^ glt i     : i
 ^ glt o     : o
-^ glt u     : y
+^ glt u     : u
 ^ glt schwa : e
 

--- a/examples/output/kwakwala_umista_alt.thyo
+++ b/examples/output/kwakwala_umista_alt.thyo
@@ -96,12 +96,19 @@ glt schwa @lastVow=on : a U+0331 !lastVow=on
 # Note: something like "gwa'um'i" will fail
 # at "'i" because there's no plain pattern
 # for "glt i". Thus, we have to add the following
-# patterns
+# patterns.
+# Update: These are no longer necessary; fixed
+# the issue; previously, there would be cases
+# where there was a partial set of guards, thus
+# causing the entire program to error. Now, instead,
+# those guard-sets have an addition an additional
+# "otherwise" guard that runs "fail", which triggers
+# backtracking.
 
-glt a     : ' a !lastVow=on
-glt e     : ' e !lastVow=on
-glt i     : ' i !lastVow=on
-glt o     : ' o !lastVow=on
-glt u     : ' u !lastVow=on
-glt schwa : ' a U+0331 !lastVow=on
+# glt a     : ' a !lastVow=on
+# glt e     : ' e !lastVow=on
+# glt i     : ' i !lastVow=on
+# glt o     : ' o !lastVow=on
+# glt u     : ' u !lastVow=on
+# glt schwa : ' a U+0331 !lastVow=on
 

--- a/examples/output/kwakwala_umista_alt.thyo
+++ b/examples/output/kwakwala_umista_alt.thyo
@@ -1,0 +1,107 @@
+name : umista2
+
+default case : /at
+
+====
+
+# Apostrophes
+# class apost : ' ` U+0313 U+0315
+
+# class underline : U+02CD U+0320 U+0332 U+0331
+
+# class lh : Ɫ ɫ ɬ U+A7AD
+
+# clas lab : W w ʷ
+
+auto state lastVow
+
+====
+
+m  : m
+m' : ' m
+n  : n
+n' : ' n
+
+# ɫł
+l  : l
+l' : ' l
+lh : ł
+
+j  : y
+j' : ' y
+
+w  : w
+w' : ' w
+
+p  : p
+p' : p U+0313
+b  : b
+
+# U+02CD
+t   : t
+ts  : t s
+ts' : t U+0315 s
+tl  : t ɫ
+tl' : t U+0315 ɫ
+
+d   : d
+dl  : d ɫ
+dz  : d z
+s   : s
+
+k   : k
+k'  : k U+0313
+kw  : k w
+kw' : k U+0315 w
+
+q   : k U+0331
+q'  : k U+0331 U+0313
+qw  : k U+0331 w
+qw' : k U+0331 U+0315 w
+
+g   : g
+gw  : g w
+gh  : g U+0331
+ghw : g U+0331 w
+
+x   : x
+xw  : x w
+xh  : x U+0331
+xhw : x U+0331 w
+
+h   : h
+glt : '
+
+a     : a !lastVow=on
+e     : e !lastVow=on
+i     : i !lastVow=on
+o     : o !lastVow=on
+u     : u !lastVow=on
+schwa : a U+0331 !lastVow=on
+
+^ glt a     : a !lastVow=on
+^ glt e     : e !lastVow=on
+^ glt i     : i !lastVow=on
+^ glt o     : o !lastVow=on
+^ glt u     : u !lastVow=on
+^ glt schwa : a U+0331 !lastVow=on
+
+glt a     @lastVow=on : a !lastVow=on
+glt e     @lastVow=on : e !lastVow=on
+glt i     @lastVow=on : i !lastVow=on
+glt o     @lastVow=on : o !lastVow=on
+glt u     @lastVow=on : u !lastVow=on
+glt schwa @lastVow=on : a U+0331 !lastVow=on
+
+# Note: something like "gwa'um'i" will fail
+# at "'i" because there's no plain pattern
+# for "glt i". Thus, we have to add the following
+# patterns
+
+glt a     : ' a !lastVow=on
+glt e     : ' e !lastVow=on
+glt i     : ' i !lastVow=on
+glt o     : ' o !lastVow=on
+glt u     : ' u !lastVow=on
+glt schwa : ' a U+0331 !lastVow=on
+

--- a/examples/parsing/backtrack_example.thyp
+++ b/examples/parsing/backtrack_example.thyp
@@ -1,0 +1,37 @@
+
+orthography : backtrack
+phoneme set : backtrack
+
+====
+
+# no classes/states?
+
+====
+
+# Vowels
+e : e
+o : o
+u : u
+i : i
+a : a
+ough : o u g h
+aw : a w
+
+# consonants
+t  : t
+d  : d
+k  : k
+g  : g
+m  : m
+n  : n
+ng : n g
+s  : s
+l  : l
+r  : r
+w  : w
+p  : p
+b  : b
+f  : f
+v  : v
+h  : h
+

--- a/examples/parsing/kwakwala_boas.thyp
+++ b/examples/parsing/kwakwala_boas.thyp
@@ -30,6 +30,8 @@ e : ê        !lastVow=on
 e : e U+0302 !lastVow=on
 e : ë        !lastVow=on
 e : e U+0308 !lastVow=on
+e : ä        !lastVow=on
+e : a U+0308 !lastVow=on
 
 o : ô        !lastVow=on
 o : o U+0302 !lastVow=on
@@ -40,8 +42,6 @@ i : ī        !lastVow=on
 i : i U+0304 !lastVow=on
 i : ē        !lastVow=on
 i : e U+0304 !lastVow=on
-i : ä        !lastVow=on
-i : a U+0308 !lastVow=on
 i : i        !lastVow=on
 i : e        !lastVow=on
 
@@ -166,6 +166,8 @@ glt a : @lastVow=on a U+0304 !lastVow=on
 glt e : @lastVow=on ê        !lastVow=on
 glt e : @lastVow=on e U+0302 !lastVow=on
 glt e : @lastVow=on ë        !lastVow=on
+glt e : @lastVow=on ä        !lastVow=on
+glt e : @lastVow=on a U+0308 !lastVow=on
 
 glt o : @lastVow=on ô        !lastVow=on
 glt o : @lastVow=on o U+0302 !lastVow=on
@@ -176,8 +178,6 @@ glt i : @lastVow=on ī        !lastVow=on
 glt i : @lastVow=on i U+0304 !lastVow=on
 glt i : @lastVow=on ē        !lastVow=on
 glt i : @lastVow=on e U+0304 !lastVow=on
-glt i : @lastVow=on ä        !lastVow=on
-glt i : @lastVow=on a U+0308 !lastVow=on
 glt i : @lastVow=on i        !lastVow=on
 glt i : @lastVow=on e        !lastVow=on
 
@@ -203,6 +203,8 @@ glt a : ^ a U+0304 !lastVow=on
 glt e : ^ ê        !lastVow=on
 glt e : ^ e U+0302 !lastVow=on
 glt e : ^ ë        !lastVow=on
+glt e : ^ ä        !lastVow=on
+glt e : ^ a U+0308 !lastVow=on
 
 glt o : ^ ô        !lastVow=on
 glt o : ^ o U+0302 !lastVow=on
@@ -213,8 +215,6 @@ glt i : ^ ī        !lastVow=on
 glt i : ^ i U+0304 !lastVow=on
 glt i : ^ ē        !lastVow=on
 glt i : ^ e U+0304 !lastVow=on
-glt i : ^ ä        !lastVow=on
-glt i : ^ a U+0308 !lastVow=on
 glt i : ^ i        !lastVow=on
 glt i : ^ e        !lastVow=on
 

--- a/examples/parsing/kwakwala_boas.thyp
+++ b/examples/parsing/kwakwala_boas.thyp
@@ -1,0 +1,246 @@
+orthography : boas
+phoneme set : kwakwala
+
+====
+
+auto state lastVow
+
+# mid-point dot
+class dot : U+00B7 U+2027
+class upU : ᵘ U+0367
+
+
+====
+
+# Vowels
+
+# !lastVow=on
+
+schwa : ă        !lastVow=on
+schwa : a U+0306 !lastVow=on
+schwa : U+1D07   !lastVow=on # smallcaps E
+schwa : î        !lastVow=on
+schwa : i U+0302 !lastVow=on
+
+a : a !lastVow=on
+a : ā !lastVow=on
+a : a U+0304 !lastVow=on
+
+e : ê        !lastVow=on
+e : e U+0302 !lastVow=on
+e : ë        !lastVow=on
+e : e U+0308 !lastVow=on
+
+o : ô        !lastVow=on
+o : o U+0302 !lastVow=on
+o : â        !lastVow=on
+o : a U+0302 !lastVow=on
+
+i : ī        !lastVow=on
+i : i U+0304 !lastVow=on
+i : ē        !lastVow=on
+i : e U+0304 !lastVow=on
+i : ä        !lastVow=on
+i : a U+0308 !lastVow=on
+i : i        !lastVow=on
+i : e        !lastVow=on
+
+u : o !lastVow=on
+u : u !lastVow=on
+u : ō !lastVow=on
+u : ū !lastVow=on
+u : o U+0304 !lastVow=on
+u : u U+0304 !lastVow=on
+
+# Cononants
+
+m  : m
+m' : ᵋ m
+
+n  : n
+n' : ᵋ n
+
+w  : w
+w' : ᵋ w
+
+j  : y
+j' : ᵋ y
+
+l  : l
+l' : ᵋ l
+
+h  : h
+b  : b
+p  : p
+p' : p \!
+
+ts  : t s
+ts' : t s \!
+dz  : d z
+
+lh : ~ ł
+lh : ~ ɫ
+lh : ~ ɬ
+lh : ~ ƚ
+
+tl  : ~ Ł
+tl  : ~ Ƚ 
+tl' : ~ Ł \!
+tl' : ~ Ƚ \! 
+dl  : ~ Ł U+0323 
+dl  : ~ Ƚ U+0323
+dl  : ~ Ḷ
+
+t  : t
+t' : t \!
+d  : d
+s  : s
+
+# Velars and Uvulars
+g   : g
+g   : g *dot
+gw  : g *dot w
+gw  : g ᵘ
+gw  : g U+0367 # combining above
+gh  : ġ
+gh  : g U+0323
+ghw : ġ ᵘ
+ghw : ġ U+0367 # ?
+ghw : g U+0323 ᵘ
+ghw : g U+0323 U+0367
+ghw : g U+0367 U+0323
+
+k : k
+k : k *dot
+k' : k \!
+k' : k *dot \!
+kw : k w
+kw : k ᵘ
+kw : k U+0367
+kw : k *dot w
+kw : k *dot ᵘ
+kw : k U+0367 *dot
+
+kw' : k w \!
+kw' : k ᵘ \!
+kw' : k U+0367 \!
+kw' : k *dot w \!
+kw' : k *dot \! w
+kw' : k \! w
+kw' : k w \!
+kw' : k *dot ᵘ \!
+kw' : k U+0367 *dot \!
+
+q   : q
+q'  : q \!
+qw' : q \! w
+qw' : q *upU \!
+
+x   : x *dot
+x   : ẋ
+xw  : x *dot w
+xw  : x *dot *upU
+xw  : ẋ w
+xw  : ẋ *upU
+xh  : x
+xhw : x *upU
+xhw : x w
+
+
+glt : ᵋ
+
+====
+
+# post-vowel
+
+glt schwa : @lastVow=on ă        !lastVow=on
+glt schwa : @lastVow=on a U+0306 !lastVow=on
+glt schwa : @lastVow=on U+1D07   !lastVow=on # smallcaps E
+glt schwa : @lastVow=on î        !lastVow=on
+glt schwa : @lastVow=on i U+0302 !lastVow=on
+
+glt a : @lastVow=on a !lastVow=on
+glt a : @lastVow=on ā !lastVow=on
+glt a : @lastVow=on a U+0304 !lastVow=on
+
+glt e : @lastVow=on ê        !lastVow=on
+glt e : @lastVow=on e U+0302 !lastVow=on
+glt e : @lastVow=on ë        !lastVow=on
+
+glt o : @lastVow=on ô        !lastVow=on
+glt o : @lastVow=on o U+0302 !lastVow=on
+glt o : @lastVow=on â        !lastVow=on
+glt o : @lastVow=on a U+0302 !lastVow=on
+
+glt i : @lastVow=on ī        !lastVow=on
+glt i : @lastVow=on i U+0304 !lastVow=on
+glt i : @lastVow=on ē        !lastVow=on
+glt i : @lastVow=on e U+0304 !lastVow=on
+glt i : @lastVow=on ä        !lastVow=on
+glt i : @lastVow=on a U+0308 !lastVow=on
+glt i : @lastVow=on i        !lastVow=on
+glt i : @lastVow=on e        !lastVow=on
+
+glt u : @lastVow=on o !lastVow=on
+glt u : @lastVow=on u !lastVow=on
+glt u : @lastVow=on ō !lastVow=on
+glt u : @lastVow=on ū !lastVow=on
+glt u : @lastVow=on o U+0304 !lastVow=on
+glt u : @lastVow=on u U+0304 !lastVow=on
+
+# At start
+
+glt schwa : ^ ă        !lastVow=on
+glt schwa : ^ a U+0306 !lastVow=on
+glt schwa : ^ U+1D07   !lastVow=on # smallcaps E
+glt schwa : ^ î        !lastVow=on
+glt schwa : ^ i U+0302 !lastVow=on
+
+glt a : ^ a !lastVow=on
+glt a : ^ ā !lastVow=on
+glt a : ^ a U+0304 !lastVow=on
+
+glt e : ^ ê        !lastVow=on
+glt e : ^ e U+0302 !lastVow=on
+glt e : ^ ë        !lastVow=on
+
+glt o : ^ ô        !lastVow=on
+glt o : ^ o U+0302 !lastVow=on
+glt o : ^ â        !lastVow=on
+glt o : ^ a U+0302 !lastVow=on
+
+glt i : ^ ī        !lastVow=on
+glt i : ^ i U+0304 !lastVow=on
+glt i : ^ ē        !lastVow=on
+glt i : ^ e U+0304 !lastVow=on
+glt i : ^ ä        !lastVow=on
+glt i : ^ a U+0308 !lastVow=on
+glt i : ^ i        !lastVow=on
+glt i : ^ e        !lastVow=on
+
+glt u : ^ o !lastVow=on
+glt u : ^ u !lastVow=on
+glt u : ^ ō !lastVow=on
+glt u : ^ ū !lastVow=on
+glt u : ^ o U+0304 !lastVow=on
+glt u : ^ u U+0304 !lastVow=on
+
+
+# *ŭ
+
+kw  schwa : k ŭ !lastVow=on
+gw  schwa : g ŭ !lastVow=on
+qw  schwa : q ŭ !lastVow=on
+xhw schwa : x ŭ !lastVow=on
+xw  schwa : ẋ ŭ !lastVow=on
+xw  schwa : x U+0323 ŭ !lastVow=on
+xw  schwa : x U+0307 ŭ !lastVow=on
+kw' schwa : k \! ŭ !lastVow=on
+qw' schwa : q \! ŭ !lastVow=on
+ghw schwa : g U+0323 ŭ !lastVow=on
+ghw schwa : g U+0307 ŭ !lastVow=on
+
+
+
+
+

--- a/examples/parsing/kwakwala_grubb.thyp
+++ b/examples/parsing/kwakwala_grubb.thyp
@@ -77,7 +77,7 @@ a     : a
 e     : e h
 i     : i
 o     : o
-u     : y
+u     : u
 schwa : e
 
 ====
@@ -86,5 +86,5 @@ glt a     : ^ a
 glt e     : ^ e h
 glt i     : ^ i
 glt o     : ^ o
-glt u     : ^ y
+glt u     : ^ u
 glt schwa : ^ e

--- a/examples/parsing/kwakwala_umista.thyp
+++ b/examples/parsing/kwakwala_umista.thyp
@@ -100,7 +100,7 @@ a     : a
 e     : e
 i     : i
 o     : o
-u     : y
+u     : u
 schwa : a *underline
 
 ====
@@ -109,6 +109,6 @@ glt a     : ^ a
 glt e     : ^ e
 glt i     : ^ i
 glt o     : ^ o
-glt u     : ^ y
+glt u     : ^ u
 glt schwa : ^ a *underline
 

--- a/examples/phonemes/backtrack_test.thym
+++ b/examples/phonemes/backtrack_test.thym
@@ -1,0 +1,32 @@
+
+# no traits or aspects
+
+====
+
+* vowel
+  e
+  o
+  u
+  i
+  a
+  ough
+  aw
+* consonant
+  t
+  d
+  k
+  g
+  m
+  n
+  ng
+  s
+  l
+  r
+  w
+  p
+  b
+  f
+  v
+  h
+
+

--- a/examples/phonemes/kwakwala.thym
+++ b/examples/phonemes/kwakwala.thym
@@ -24,6 +24,7 @@ p'
 b  
 
 t   
+t'
 ts  
 ts' 
 tl  

--- a/metamorTHysis.cabal
+++ b/metamorTHysis.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -84,8 +84,6 @@ library
       Metamorth.Interpretation.Phonemes.Types
   other-modules:
       Paths_metamorTHysis
-  autogen-modules:
-      Paths_metamorTHysis
   hs-source-dirs:
       src
   default-extensions:
@@ -115,8 +113,6 @@ library
 executable metamorTHysis-exe
   main-is: Main.hs
   other-modules:
-      Paths_metamorTHysis
-  autogen-modules:
       Paths_metamorTHysis
   hs-source-dirs:
       app
@@ -159,8 +155,6 @@ test-suite metamorTHysis-test
       Test.TH.Kwakwala
       Test.TH.Mongolian
       Test.TH.TwoOrths
-      Paths_metamorTHysis
-  autogen-modules:
       Paths_metamorTHysis
   hs-source-dirs:
       test

--- a/metamorTHysis.cabal
+++ b/metamorTHysis.cabal
@@ -151,6 +151,7 @@ test-suite metamorTHysis-test
   other-modules:
       Test.Monad.Matcher
       Test.Monad.Matcher2
+      Test.TH.Backtrack
       Test.TH.Basic
       Test.TH.Following
       Test.TH.Grouped

--- a/metamorTHysis.cabal
+++ b/metamorTHysis.cabal
@@ -84,6 +84,8 @@ library
       Metamorth.Interpretation.Phonemes.Types
   other-modules:
       Paths_metamorTHysis
+  autogen-modules:
+      Paths_metamorTHysis
   hs-source-dirs:
       src
   default-extensions:
@@ -113,6 +115,8 @@ library
 executable metamorTHysis-exe
   main-is: Main.hs
   other-modules:
+      Paths_metamorTHysis
+  autogen-modules:
       Paths_metamorTHysis
   hs-source-dirs:
       app
@@ -155,6 +159,8 @@ test-suite metamorTHysis-test
       Test.TH.Kwakwala
       Test.TH.Mongolian
       Test.TH.TwoOrths
+      Paths_metamorTHysis
+  autogen-modules:
       Paths_metamorTHysis
   hs-source-dirs:
       test

--- a/src/Metamorth/ForOutput/Monad/EitherFail.hs
+++ b/src/Metamorth/ForOutput/Monad/EitherFail.hs
@@ -116,3 +116,99 @@ instance Semigroup (EitherFail a) where
 instance Monoid (EitherFail a) where
   mempty = EmptyF
 
+------------------------------------------------
+-- Alternative Laws:
+
+-- empty is a neutral element
+-- (1) empty <|> u  =  u
+-- (2) u <|> empty  =  u
+
+-- Proof : (From definition of (<|>))
+-- empty === EmptyF
+-- EmptyF <|> x = x (1)
+-- x <|> EmptyF = x (2)
+
+-- (<|>) is associative
+-- u <|> (v <|> w)  =  (u <|> v) <|> w (3)
+
+-- Case 1: u == EmptyF:
+-- EmptyF <|> (v <|> w) 
+-- == v <|> w
+-- By (1), we know that (EmptyF <|> v) = v
+-- Therefore, we can substitute v ==> (EmptyF <|> v)
+-- == (EmptyV <|> v) <|> w (3.1)
+
+-- Case 2: w == EmptyF:
+-- Similar to above; we know (v <|> EmptyF) == v, so...
+-- u <|> (v <|> w)
+-- == u <|> (v <|> EmptyF)
+-- == u <|> v
+-- == (u <|> v)
+-- == (u <|> v) <|> EmptyF by (2)
+-- (3.2)
+
+-- Case 3: v == EmptyF
+-- (Not going to write this one out; similar to 3.1 and 3.2)
+
+-- Case 4: All values are LeftF
+-- u <|> (v <|> w)  =?=  (u <|> v) <|> w
+-- (LeftF u) <|> ((LeftF v) <|> (LeftF w)) =?= ((LeftF u) <|> (LeftF v)) <|> (LeftF w)
+-- LeftF (u ++ "\n" ++ (v ++ "\n" ++ w)) =?= LeftF ((u ++ "\n" ++ v) ++ "\n" ++ w)
+-- LeftF (u ++ "\n" ++ v ++ "\n" ++ w) == LeftF (u ++ "\n" ++ v ++ "\n" ++ w)
+-- (By associativity of (++)/(<>))
+-- Therefore, (3.4) holds
+
+-- Case 5: u == RightF x
+-- From the definition of (<|>) for EitherFail, 
+-- (RightF x <|> _) == RightF x
+-- Thus, (RightF x) <|> (v <|> w) == RightF x (a)
+--       (RightF x) <|>  v        == RightF x (b)
+--       (RightF x) <|>  w        == RightF x (c)
+
+-- u <|> (v <|> w)  =  (u <|> v) <|> w (3)
+-- (RightF x) <|> (v <|> w) =?=  ((RightF x) <|> v) <|> w
+-- (RightF x) =?= ((RightF x) <|> v) <|> w   by (a)
+-- (RightF x) =?= (RightF x) <|> w           by (b)
+-- (RightF x) === (RightF x)                 by (c)
+--
+-- Therefore, (3.5) holds.
+
+-- Case 6: v == RightF x, and u == EmptyF or (LeftF e)
+
+-- Therefore...
+-- EmptyF    <|> (RightF x) == RightF x
+-- (LeftF e) <|> (RightF x) == RightF x
+-- Therefore, u <|> (RightF x) == RightF x (d)
+
+-- u <|> (v <|> w)  =?=  (u <|> v) <|> w
+-- u <|> ((RightF x) <|> w) =?= (u <|> (RightF x)) <|> w
+-- u <|> ((RightF x)) =?= (u <|> (RightF x)) <|> w   by (3.5c)
+-- (RightF x) =?= (u <|> (RightF x)) <|> w           by (d)
+-- (RightF x) =?= (RightF x) <|> w                   by (d)
+-- RightF x == RightF x                              by (3.5c)
+
+-- Therefore, (3.6 holds)
+
+-- Case 7: w == RightF x, and u/v == EmptyF or LeftF e/f
+
+-- EmptyF    <|> (RightF x) == RightF x
+-- (LeftF e) <|> (RightF x) == RightF x
+-- Therefore, v <|> (RightF x) == RightF x (e)
+
+-- EmptyF <|> EmptyF == EmptyF
+-- EmptyF <|> (LeftF f) == LeftF f
+-- (LeftF e) <|> EmptyF == LeftF e
+-- (LeftF e) <|> (LeftF f) == LeftF (e ++ "\n" ++ f)
+-- Therefore, (u <|> v) == EmptyF or LeftF g, for some g (f).
+
+-- u <|> (v <|> w)  =?=  (u <|> v) <|> w
+-- u <|> (v <|> (RightF x))  =?=  (u <|> v) <|> (RightF x)
+-- u <|> (RightF x)  =?=  (u <|> v) <|> (RightF x)   by (e)
+-- u <|> (RightF x)  =?=  (LeftF g) <|> (RightF x)   by (f)
+-- u <|> (RightF x)  =?=  (RightF x)                 by definition of (<|>)
+-- (RightF x) == (RightF x)                          by (3.6d)
+
+-- Therefore, since all cases hold, condition (3) holds.
+
+-- Thus, `EitherFail` satisfies the `Alternative` laws.
+

--- a/src/Metamorth/ForOutput/Monad/Matcher/Stateful.hs
+++ b/src/Metamorth/ForOutput/Monad/Matcher/Stateful.hs
@@ -227,19 +227,30 @@ pullValues = MatcherT $ \_ifnc inp vs st -> pure (vs, inp, mempty, st)
 get :: (Applicative m) => MatcherT i v s m s
 get = MatcherT $ \_ifnc inp vs st -> pure (st,inp,vs,st)
 
--- | Retrieve the current state.
+-- | Retrieve the current state, using a view function on it.
 gets :: (Applicative m) => (s -> s') -> MatcherT i v s m s'
 gets f = MatcherT $ \_ifnc inp vs st -> pure (f st, inp, vs, st)
 
+-- | Modify the current state of the `MatcherT`.
 modify :: (Applicative m) => (s -> s) -> MatcherT i v s m ()
 modify f = MatcherT $ \_ifnc inp vs st -> pure ((), inp, vs, f st)
 
+-- | Strictly modify the current state of the `MatcherT`. Based
+--   on `Control.Monad.Trans.State.Strict.modify'` from 
+--   "Control.Monad.Trans.State.Strict".
 modify' :: (Applicative m) => (s -> s) -> MatcherT i v s m ()
 modify' f = MatcherT $ \_ifnc inp vs st -> pure ((), inp, vs, f $! st)
 
+-- | Set the current state of the `MatcherT` to a specific value.
 put :: (Applicative m) => s -> MatcherT i v s m ()
 put st = MatcherT $ \_ifnc inp vs _ -> pure ((), inp, vs, st)
 
+-- | Match on the input stream by applying a `MatchResult` action
+--   to the next value in the stream, and then either:
+--
+--     - Returning, if the the action returns a `MatchReturn`.
+--     - Throwing an error, if the action returns a `MatchFail`.
+--     - Running `match` on the next value in the stream, if the action returns a `MatchContinue` or `MatchOptions`.
 match :: (MonadPlus m, Monoid v) => (String -> m r) -> (i -> MatchResult m i v s r) -> MatcherT i v s m r
 match err f = do
   mybX <- proceed
@@ -542,9 +553,27 @@ matchesSimpleDef defVal action = do
 --         ((mt2 ifnc inp vs st) `mplus` (mt3 ifnc inp vs st))
 --
 --   == MatcherT $ \ifnc inp vs st ((mt1 ifnc inp vs st) `mplus` (mt2 ifnc inp vs st)) `mplus`
---         (mt3 ifnc inp vs st)    by associativity of `mplus` on the base monad.
+--         (mt3 ifnc inp vs st)    by associativity of `mplus` on the base monad. (3.1)
 
--- ... which can be shown to be equivalent to "(u <|> v) <|> w", as required for (3).
+-- ... which can be shown to be equivalent to "(u <|> v) <|> w":
+
+-- (u <|> v) <|> w
+--   == ((MatcherT mt1) <|> (MatcherT mt2)) <|> (MatcherT mt3)
+--   == (MatcherT $ \ifnc inp vs st -> (mt1 ifnc inp vs st) `mplus` (mt2 ifnc inp vs st)) <|> (MatcherT mt3)
+--
+-- Let mtUV = \ifnc' inp' vs' st' -> (mt1 ifnc' inp' vs' st') `mplus` (mt2 ifnc' inp' vs' st')
+--
+--   == (MatcherT mtUV) <|> (MatcherT mt3)
+--   == MatcherT $ \ifnc inp vs st -> (mtUV ifnc inp vs st) `mplus` (mt3 ifnc inp vs st)
+--  
+--        (mtUV ifnc inp vs st)
+--     == (\ifnc' inp' vs' st' -> (mt1 ifnc' inp' vs' st') `mplus` (mt2 ifnc' inp' vs' st')) ifnc inp vs st
+--     == (mt1 ifnc inp vs st) `mplus` (mt2 ifnc inp vs st)
+--
+--   == MatcherT $ \ifnc inp vs st -> ((mt1 ifnc inp vs st) `mplus` (mt2 ifnc inp vs st)) `mplus` 
+--         (mt3 ifnc inp vs st)
+
+-- ... which is the same as equation (3.1).
 
 -- Therefore, (`MatcherT` i v s m) satisfies the Alternative/MonadPlus laws
 -- so long as `m` also satisfies those laws.

--- a/src/Metamorth/Helpers/Parsing.hs
+++ b/src/Metamorth/Helpers/Parsing.hs
@@ -17,6 +17,7 @@ module Metamorth.Helpers.Parsing
   , some_
   , many'_
   , some'_
+  , optionalBool
 
   -- * Re-ordered Functions
   , forParseOnly
@@ -51,6 +52,7 @@ import Control.Monad.Trans.RWS.CPS      qualified as RWS
 import Data.Functor
 import Data.Text qualified as T
 import Data.Char (isAlphaNum)
+import Data.Maybe (isJust)
 
 -- | Skip horizontal spaces until a non-space
 --   or non-horizontal space is encountered.
@@ -198,3 +200,9 @@ many'_ f = AT.many' f $> ()
 
 some'_ :: MonadPlus m => m a -> m ()
 some'_ f = AT.many1' f $> ()
+
+-- | Like `optional`, but for parsers that return ().
+--   Instead of returning a value of type @Maybe ()@,
+--   it returns 
+optionalBool :: Alternative f => f () -> f Bool
+optionalBool f = isJust <$> optional f

--- a/src/Metamorth/Interaction/Quasi/Parser.hs
+++ b/src/Metamorth/Interaction/Quasi/Parser.hs
@@ -218,22 +218,22 @@ parseSuffix = do
 
 parseInSuffix :: ParserQQ1 ()
 parseInSuffix = do
-  _ <- "suffix-in" <|> "in-suffix"
-  parseKeySep' "in-suffix"
+  fld <- "suffix-in" <|> "in-suffix"
+  parseKeySep' $ T.unpack fld
   str <- liftQQ1 (parseQuoteString <|> parseUnquoteString)
   setInSuffix str
 
 parseOutSuffix :: ParserQQ1 ()
 parseOutSuffix = do
-  _ <- "suffix-out" <|> "out-suffix"
-  parseKeySep' "out-suffix"
+  fld <- "suffix-out" <|> "out-suffix"
+  parseKeySep' $ T.unpack fld
   str <- liftQQ1 (parseQuoteString <|> parseUnquoteString)
   setInSuffix str
 
 parseInputName :: ParserQQ1 ()
 parseInputName = do
-  _ <- "parser-name" <|> "input-name"
-  parseKeySep' "input-name"
+  fld <- "parser-name" <|> "input-name"
+  parseKeySep' $ T.unpack fld
   str <- liftQQ1 (parseQuoteString <|> parseUnquoteString)
   setInputName str
 
@@ -247,22 +247,22 @@ parseOutputName = do
 parseExtension :: ParserQQ1 ()
 parseExtension = do
   _ <- "ext"
-  _ <- optional "ension"
-  parseKeySep' "extension"
+  z <- isJust <$> optional "ension"
+  parseKeySep' (if z then "extension" else "ext")
   ext <- liftQQ1 (parseQuoteString <|> parseUnquoteString)
   setExtension ext
 
 parseDescription :: ParserQQ1 ()
 parseDescription = do
-  _ <- "dsc" <|> "description"
-  parseKeySep' "description"
+  fld <- "dsc" <|> "description"
+  parseKeySep' $ T.unpack fld
   dsc <- liftQQ1 (parseQuoteLineString <|> parseUnquoteLineString)
   setDescription dsc
 
 parseFailedOption :: ParserQQ1 ()
 parseFailedOption = do
   optName <- liftQQ1 $ AT.takeWhile (\c -> isAlpha c || c == '-' || c == '_')
-  parseKeySep' "<failed_option>"
+  parseKeySep' $ T.unpack optName
   strs <- liftQQ1 (AT.sepBy' (parseQuoteString <|> parseUnquoteString) parseListSep)
   case strs of
     []    -> lift $ tellError $ "Couldn't parse option \"" ++ T.unpack optName ++ "\" with empty value list."
@@ -270,6 +270,7 @@ parseFailedOption = do
     _     -> lift $ tellError $ "Couldn't parse option \"" ++ T.unpack optName ++ "\" with values " ++ (intercalate ", " (map quotify strs)) ++ "."
   where
     quotify str = '\"' : (str ++ "\"")
+
 
 {-
   -- | Whether to unify branches for parser.

--- a/src/Metamorth/Interaction/Quasi/Parser.hs
+++ b/src/Metamorth/Interaction/Quasi/Parser.hs
@@ -123,15 +123,15 @@ parseOrthographyBlock = do
 
 parsePhoneFileName :: ParserQQ String
 parsePhoneFileName = do
-  _ <- "phonemes" <|> "phoneme set" <|> "phoneme-set" <|> "phones"
-  lift parseKeySep
+  fld <- "phonemes" <|> "phoneme set" <|> "phoneme-set" <|> "phones"
+  parseKeySepX $ T.unpack fld
   lift (parseQuoteString <|> parseUnquoteString)
 
 parseLanguageName :: ParserQQ String
 parseLanguageName = do
   _ <- "lang"
-  _ <- optional "uage"
-  lift parseKeySep
+  z <- isJust <$> optional "uage"
+  parseKeySepX $ if z then "language" else "lang"
   lift (parseQuoteString <|> parseUnquoteString)
 
 parseHeader :: ParserQQ (String, Maybe String)
@@ -147,7 +147,7 @@ parseHeader = do
         return lng
       return (fp, lang)
     (Left lang) -> do
-      fp <- parsePhoneFileName
+      fp <- parsePhoneFileName <|> fail "Missing Phoneme File Location"
       lift $ many'_ consumeEndComment
       return (fp, Just lang)
 

--- a/src/Metamorth/Interaction/Quasi/Parser/Helpers.hs
+++ b/src/Metamorth/Interaction/Quasi/Parser/Helpers.hs
@@ -3,6 +3,7 @@ module Metamorth.Interaction.Quasi.Parser.Helpers
   ( countHoriz
   , consumeEndComment
   , parseBool
+  , (<|?>)
   -- * Parsing Items in Lists
   , parseQuoteString
   , parseQuoteText
@@ -555,6 +556,14 @@ quotedList' []  = "[]"
 quotedList' [x] = '\"' : x ++ "\""
 quotedList' [x,y] = '\"' : x ++ "\", and \"" ++ y ++ "\""
 quotedList' (x:xs) = '\"' : x ++ "\", " ++ (quotedList' xs)
+
+-- | A simple way to determine which of two 
+--   options was chosen, where you don't care
+--   about the value of the two options.
+(<|?>) :: Alternative f => f a -> f b -> f Bool
+op1 <|?>  op2 = (op1 $> True) <|> (op2 $> False)
+
+infixl 3 <|?>
 
 --------------------------------
 -- Multi-Sets

--- a/src/Metamorth/Interpretation/Output/Parsing.hs
+++ b/src/Metamorth/Interpretation/Output/Parsing.hs
@@ -96,8 +96,8 @@ parseOutputFile grps trts asps phones = do
         }
   return (opo, hdr, msgs)
 
-getAutoStates :: M.Map String (Bool, Maybe a) -> S.Set String
-getAutoStates = M.keysSet . (M.filter fst)
+getAutoStates :: M.Map String (Bool, Maybe a) -> M.Map String Bool
+getAutoStates = (M.map (isJust . snd)) . (M.filter fst)
 
 ----------------------------------------------------------------
 -- Section Parsers

--- a/src/Metamorth/Interpretation/Output/Parsing.hs
+++ b/src/Metamorth/Interpretation/Output/Parsing.hs
@@ -87,13 +87,17 @@ parseOutputFile grps trts asps phones = do
     parsePatternSection
     -- return hdr
   let opo = OutputParserOutput
-        { opoStateDictionary  = opsStateDictionary ops
+        { opoStateDictionary  = fmap snd $ opsStateDictionary ops
+        , opoAutoStates       = getAutoStates $ opsStateDictionary ops
         , opoTraitDictionary  = opsTraitDictionary ops
         , opoGroupDictionary  = opsGroupDictionary ops
         , opoAspectDictionary = opsAspectDictionary ops
         , opoOutputTrie = opsOutputTrie ops
         }
   return (opo, hdr, msgs)
+
+getAutoStates :: M.Map String (Bool, Maybe a) -> S.Set String
+getAutoStates = M.keysSet . (M.filter fst)
 
 ----------------------------------------------------------------
 -- Section Parsers
@@ -268,8 +272,11 @@ getGroup = do
 -- State Info Parsers
 ----------------------------------------------------------------
 
-parseStateDec :: AT.Parser (String, Maybe (S.Set String))
+parseStateDec :: AT.Parser (String, Bool, Maybe (S.Set String))
 parseStateDec = do
+  isAuto <- optionalBool $ do
+    parseAutoOff
+    void "-" <|> skipHoriz1 -- to allow "auto-state" etc...
   _ <- "state"
   skipHoriz1
   stateName <- takeIdentifier isLower isFollowId
@@ -283,19 +290,26 @@ parseStateDec = do
   case vals of
     Nothing -> return ()
     (Just xs) -> when (not $ allUnique xs) $ fail $ "State \"" <> (T.unpack stateName) <> "\" has multiple options with the same name."
-  return (T.unpack stateName, (S.fromList . map T.unpack) <$> vals)
+  return (T.unpack stateName, isAuto, (S.fromList . map T.unpack) <$> vals)
 
 -- | Parse a state declaration and add it to
 --   the state dictionary.
 parseStateDecS :: OutputParser ()
 parseStateDecS = do
-  (stName, stSet) <- lift parseStateDec
+  (stName, stIsAuto, stSet) <- lift parseStateDec
   theMap <- gets opsStateDictionary
   case (M.lookup stName theMap) of
     (Just _) -> mkError $ "Error: state \"" <> stName <> "\" has multiple definitions."
     Nothing  -> do
-        let newMap = M.insert stName stSet theMap
+        let newMap = M.insert stName (stIsAuto, stSet) theMap
         modify $ \x -> x {opsStateDictionary = newMap}
+
+-- | Parse the prefix for states to indicate that they
+--   are auto-off.
+parseAutoOff :: AT.Parser ()
+parseAutoOff = void
+  ("auto-off" <|> "auto" <|> "short" <|> "off")
+
 
 --------------------------------
 -- "State-must-be" Parser(s)
@@ -396,12 +410,12 @@ parseStateSetRS = do
     Nothing -> do 
       mkError $ "Couldn't find state name \"" <> st <> "\" in dictionary."
       return Nothing
-    (Just Nothing) -> case (checkBoolString val) of
+    Just (_isAuto, Nothing) -> case (checkBoolString val) of
       Nothing -> do 
         mkError $ "Couldn't interpret \"" <> val' <> "\" as boolean value for state \"" <> st <> "\"."
         return Nothing
       (Just bl) -> return $ Just (SetStateR st (Right bl))
-    (Just (Just valSet)) -> if (val' `S.member` valSet)
+    Just (_isAuto, (Just valSet)) -> if (val' `S.member` valSet)
       then (return $ Just $ SetStateR st (Left val'))
       -- need to use `checkOffString` since you can't just
       -- set an option string to `On`; you need a value to
@@ -667,12 +681,12 @@ parseStateValRSX = do
     Nothing -> do 
       mkError $ "Couldn't find state name \"" <> st <> "\" in dictionary."
       return Nothing
-    (Just Nothing) -> case (checkBoolString val) of
+    Just (_isAuto, Nothing) -> case (checkBoolString val) of
       Nothing -> do 
         mkError $ "Couldn't interpret \"" <> val' <> "\" as boolean value for state \"" <> st <> "\"."
         return Nothing
       (Just bl) -> return $ Just (PhoneValStateR st (Right bl))
-    (Just (Just valSet)) -> if (val' `S.member` valSet)
+    Just (_isAuto, (Just valSet)) -> if (val' `S.member` valSet)
       then (return $ Just $ PhoneValStateR st (Left val'))
       else case (checkBoolString val) of
         Nothing -> do
@@ -779,7 +793,7 @@ parsePhonemePatMulti' = do
     -- hmm...
     -- return ()
     
-    sdict <- gets opsStateDictionary
+    sdict <- gets (M.map snd . opsStateDictionary)
     let  ePhonePats = validatePhonePattern sdict (NE.toList phones)
     case ePhonePats of
       (Left  errs) -> do 

--- a/src/Metamorth/Interpretation/Output/Parsing.hs
+++ b/src/Metamorth/Interpretation/Output/Parsing.hs
@@ -94,7 +94,8 @@ parseOutputFile grps trts asps phones = do
         , opoAspectDictionary = opsAspectDictionary ops
         , opoOutputTrie = opsOutputTrie ops
         }
-  return (opo, hdr, msgs)
+  -- Process the auto-states for the opo.
+  return (implementAutoStates opo, hdr, msgs)
 
 getAutoStates :: M.Map String (Bool, Maybe a) -> M.Map String Bool
 getAutoStates = (M.map (isJust . snd)) . (M.filter fst)

--- a/src/Metamorth/Interpretation/Output/Parsing/Types.hs
+++ b/src/Metamorth/Interpretation/Output/Parsing/Types.hs
@@ -78,7 +78,7 @@ embedOutputParser grps trts asps phons prs
 data OutputParsingState = OutputParsingState
   -- | The state dictionary. This is updated as
   --   the parser parses the state declarations.
-  { opsStateDictionary :: M.Map String (Maybe (S.Set String))
+  { opsStateDictionary :: M.Map String (Bool, Maybe (S.Set String))
   -- | The Group "Dictionary". This is supplied by
   --   the phoneme parser when the output files
   --   are run.

--- a/src/Metamorth/Interpretation/Output/Types/Alt.hs
+++ b/src/Metamorth/Interpretation/Output/Types/Alt.hs
@@ -220,6 +220,10 @@ data OutputParserOutput = OutputParserOutput
   -- | The state dictionary. This is updated as
   --   the parser parses the state declarations.
   { opoStateDictionary :: M.Map String (Maybe (S.Set String))
+  -- | The set of States that are "auto-off". 
+  --   This can be found by just filtering the
+  --   opsStateDictionary on the first argument.
+  , opoAutoStates      :: S.Set String
   -- | The Group "Dictionary". This is supplied by
   --   the phoneme parser when the output files
   --   are run.

--- a/src/Metamorth/Interpretation/Output/Types/Alt.hs
+++ b/src/Metamorth/Interpretation/Output/Types/Alt.hs
@@ -25,6 +25,8 @@ module Metamorth.Interpretation.Output.Types.Alt
   , partAtEnds
   , partNotEnds
   , partCheckNexts
+  , addAutoStates
+  , implementAutoStates
   ) where
 
 -- Alternate forms of types.
@@ -243,4 +245,55 @@ data OutputParserOutput = OutputParserOutput
   , opoOutputTrie       :: TM.TMap PhonePatternAlt (S.Set PhoneResult)
   -- , opoOutputTrie       :: TM.TMap PhonePattern (M.Map OutputCase OutputPattern)
   } deriving (Show, Eq)
+
+------------------------------------------------
+-- Code for handling auto-off states
+
+isModState :: String -> ModifyStateX -> Bool
+isModState str (ModifyStateBB str' _) = str == str'
+isModState str (ModifyStateVV str' _) = str == str'
+isModState str (ModifyStateVX str'  ) = str == str'
+
+isModState' :: String -> PhoneResultActionX -> Bool
+isModState' str (PRModifyState ms) = isModState str ms
+isModState' _ _ = False
+
+hasModState :: String -> [PhoneResultActionX] -> Bool
+hasModState str = any (isModState' str)
+
+-- | Add a single auto-state to the list of actions.
+addAutoState :: [PhoneResultActionX] -> String -> Bool -> [PhoneResultActionX]
+addAutoState prs str typ
+  -- Already modifies this state: do nothing
+  | (hasModState str prs) = prs
+  -- Otherwise, add "turn off state" to list of actions.
+  | otherwise = newAction : prs
+  where 
+    newAction
+      | typ       = PRModifyState $ ModifyStateVX str
+      | otherwise = PRModifyState $ ModifyStateBB str False
+
+addAutoState' :: [PhoneResultActionX] -> (String, Bool) -> [PhoneResultActionX]
+addAutoState' prs = uncurry $ addAutoState prs
+
+addAutoStates' :: M.Map String Bool -> [PhoneResultActionX] -> [PhoneResultActionX]
+addAutoStates' stMap prs = foldl addAutoState' prs (M.assocs stMap)
+
+-- | Add the auto-off states to the `PhoneResult`.
+addAutoStates :: M.Map String Bool -> PhoneResult -> PhoneResult
+addAutoStates stMap prOrig = prOrig { prPhoneConditions = prActsNew }
+  where prActsNew = addAutoStates' stMap (prPhoneConditions prOrig)
+
+-- | Use the data from `OutputParserOutput` to add auto-state
+--   information to its branches.
+implementAutoStates :: OutputParserOutput -> OutputParserOutput
+implementAutoStates opo
+  -- If there are no auto-states, do nothing
+  | M.null autoSt = opo
+  | otherwise = opo {opoOutputTrie = newTrie}
+  where 
+    autoSt = opoAutoStates opo
+    newTrie = fmap (S.map $ addAutoStates autoSt) $ opoOutputTrie opo
+
+
 

--- a/src/Metamorth/Interpretation/Output/Types/Alt.hs
+++ b/src/Metamorth/Interpretation/Output/Types/Alt.hs
@@ -221,9 +221,9 @@ data OutputParserOutput = OutputParserOutput
   --   the parser parses the state declarations.
   { opoStateDictionary :: M.Map String (Maybe (S.Set String))
   -- | The set of States that are "auto-off". 
-  --   This can be found by just filtering the
-  --   opsStateDictionary on the first argument.
-  , opoAutoStates      :: S.Set String
+  --   The `Bool` indicates whether the state is
+  --   a value-state (True) or a bool-state (False).
+  , opoAutoStates      :: M.Map String Bool
   -- | The Group "Dictionary". This is supplied by
   --   the phoneme parser when the output files
   --   are run.

--- a/src/Metamorth/Interpretation/Parser/Parsing.hs
+++ b/src/Metamorth/Interpretation/Parser/Parsing.hs
@@ -101,6 +101,9 @@ parseEscaped = do
     '+' -> consProd '+'
     '-' -> consProd '-'
     '%' -> consProd '%'
+    '~' -> consProd '~'
+    '!' -> consProd '!'
+    '@' -> consProd '@'
     y   -> consProd y
 
   {- -- older version
@@ -320,7 +323,7 @@ parseStateSetRS' = do
 -- Special Char Parsers
 
 parseSpecials :: AT.Parser [Char] 
-parseSpecials = AT.sepBy (AT.satisfy (\x -> x == '+' || x == '-')) skipHoriz
+parseSpecials = AT.sepBy (AT.satisfy (\x -> x == '+' || x == '-' || x == '~')) skipHoriz
 
 parseSpecialsS :: ParserParser [Char]
 parseSpecialsS = lift parseSpecials

--- a/src/Metamorth/Interpretation/Parser/Parsing.hs
+++ b/src/Metamorth/Interpretation/Parser/Parsing.hs
@@ -381,8 +381,8 @@ parseUnspecifiedClassOrState :: ParserParser ()
 parseUnspecifiedClassOrState = do
   lift skipHoriz
   thingName <- T.unpack <$> lift (takeIdentifier isLower isFollowId)
-  lift $ skipHoriz
-  c <- lift $ AT.peekChar'
+  lift skipHoriz
+  c <- lift AT.peekChar'
   case c of
     ':' -> do
       lift $ void AT.anyChar

--- a/src/Metamorth/Interpretation/Parser/Parsing/Trie.hs
+++ b/src/Metamorth/Interpretation/Parser/Parsing/Trie.hs
@@ -123,7 +123,7 @@ generaliseStateTrie tm = forBranches tm $ \cpat mval subTrie ->
     generaliseStateTrieX tm [cpat] mval subTrie
 
 -- | Run until the first stateful pattern is found.
-generaliseStateTrieX :: TM.TMap CharPattern a -> [CharPattern] -> (Maybe a) -> TM.TMap CharPattern a -> TM.TMap CharPattern a
+generaliseStateTrieX :: TM.TMap CharPattern a -> [CharPattern] -> Maybe a -> TM.TMap CharPattern a -> TM.TMap CharPattern a
 -- Note that the patterns are built up in reverse here. This is
 -- to make it easier to inspect the latest value.
 generaliseStateTrieX topTrie ws@[WordStart] _thisVal thisTrie

--- a/src/Metamorth/Interpretation/Parser/Parsing/Types.hs
+++ b/src/Metamorth/Interpretation/Parser/Parsing/Types.hs
@@ -86,7 +86,7 @@ addPhonemesPattern phones pat = do
 
 data ParserParsingState = ParserParsingState
   { ppsClassDictionary :: M.Map String (S.Set Char)
-  , ppsStateDictionary :: M.Map String (Maybe (S.Set String))
+  , ppsStateDictionary :: M.Map String (Bool, Maybe (S.Set String))
   , ppsPhonemePatterns :: M.Map PhoneResult [PhonemePattern]
   } deriving (Show, Eq)
 

--- a/src/Metamorth/Interpretation/Parser/TH.hs
+++ b/src/Metamorth/Interpretation/Parser/TH.hs
@@ -315,7 +315,7 @@ makeTheParser'
   -> QS ([Dec], StaticParserInfo, Name)
 makeTheParser' phoneMap aspectMap phoneName mkMaj mkMin wordDataNames pps pops = do
   let classDictX = ppsClassDictionary pps
-      stateDictX = ppsStateDictionary pps
+      stateDictX = snd <$> ppsStateDictionary pps -- TODO: You'll (probably) need to modify this in the future.
       phonePats  = ppsPhonemePatterns pps
       -- mainTrie  = if (poGroupGuards pops) then (pathifyTrie phonePats) else (dontPathifyTrie phonePats)
       mainTrie   = setupTrie pops phonePats

--- a/src/Metamorth/Interpretation/Parser/TH.hs
+++ b/src/Metamorth/Interpretation/Parser/TH.hs
@@ -1570,6 +1570,7 @@ phonemeRet
 phonemeRet mkMaj mkMin c cs (Just blName) rslts
   | (cs == CMaj) = AppE ret $ formMulExp $ forMap rslts $ \rslt -> (mkMaj rslt)
   | (cs == CMin) = AppE ret $ formMulExp $ forMap rslts $ \rslt -> (mkMin rslt)
+  | (cs == CNul) = AppE ret $ formMulExp $ forMap rslts $ \rslt -> (mkMin rslt)
   | otherwise    = condCase blName mkMaj mkMin rslts
   where
     ret  = VarE 'return
@@ -1592,6 +1593,7 @@ phonemeRet'
 phonemeRet' mkMaj mkMin cs (Just blName) rslts
   | (cs == CMaj) = AppE ret $ formMulExp $ forMap rslts $ \rslt -> (mkMaj rslt)
   | (cs == CMin) = AppE ret $ formMulExp $ forMap rslts $ \rslt -> (mkMin rslt)
+  | (cs == CNul) = AppE ret $ formMulExp $ forMap rslts $ \rslt -> (mkMin rslt)
   | otherwise    = condCase blName mkMaj mkMin rslts
   where
     ret  = VarE 'return

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -10,6 +10,8 @@ import Test.TH.Kwakwala  as Kwak
 import Test.TH.Mongolian as Mongolian
 import Test.TH.Following qualified as Fol
 
+import Test.TH.Backtrack qualified as Back
+
 import Test.TH.KwakQuasi qualified as KwakQ
 
 import System.IO
@@ -142,6 +144,12 @@ main = do
   case auto2 of
     (Left err) -> putStrLn $ "Error: " ++ err
     (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
+  
+  putStrLn "Testing input backtracking..."
+  let back1 = TLE.decodeUtf8 <$> Back.convertOrthographyBS Back.InBacktrack Back.OutBacktrack2 backTest1
+  case back1 of
+    (Left err) -> putStrLn $ "Error: " ++ err
+    (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
 
 
 
@@ -172,6 +180,9 @@ boasText1 = "ăăë gŭ"
 
 autoTest2 :: T.Text
 autoTest2 = "eh'eh'a gwa'um'i" -- 
+
+backTest1 :: T.Text
+backTest1 = "tough tougra" -- 
 
 -- hmm... ...
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -137,6 +137,13 @@ main = do
     (Left err) -> putStrLn $ "Error: " ++ err
     (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
 
+  putStrLn "Testing auto-states for output..."
+  let auto2 = TLE.decodeUtf8 <$> KwakQ.convertOrthographyBS KwakQ.InGrubb KwakQ.OutUmista2 autoTest2
+  case auto2 of
+    (Left err) -> putStrLn $ "Error: " ++ err
+    (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
+
+
 
 
 -- | From the Inuktitut Wikipedia page for Inuktitut.
@@ -162,6 +169,9 @@ followText2 = "ɑgjuliʊ gæʃtɒlis θrəŋ aft iŋaninis init etes beedʒ eki�
 
 boasText1 :: T.Text
 boasText1 = "ăăë gŭ"
+
+autoTest2 :: T.Text
+autoTest2 = "eh'eh'a gwa'um'i" -- 
 
 -- hmm... ...
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -131,6 +131,12 @@ main = do
     (Left err) -> putStrLn $ "Error: " ++ err
     (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
 
+  putStrLn "Testing auto-states..."
+  let boas1 = TLE.decodeUtf8 <$> KwakQ.convertOrthographyBS KwakQ.InBoas KwakQ.OutGrubb boasText1
+  case boas1 of
+    (Left err) -> putStrLn $ "Error: " ++ err
+    (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
+
 
 
 -- | From the Inuktitut Wikipedia page for Inuktitut.
@@ -153,6 +159,9 @@ followText1 = "ɑgjuliʊ gæʃtɒlis θrəŋ aft"
 
 followText2 :: T.Text
 followText2 = "ɑgjuliʊ gæʃtɒlis θrəŋ aft iŋaninis init etes beedʒ ekiŋ"
+
+boasText1 :: T.Text
+boasText1 = "ăăë gŭ"
 
 -- hmm... ...
 

--- a/test/Test/TH/Backtrack.hs
+++ b/test/Test/TH/Backtrack.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints -Wno-unused-top-binds -Wno-unused-matches #-}
+
+module Test.TH.Backtrack
+  ( Phoneme(..)
+  , convertOrthography
+  , convertOrthographyLazy
+  , convertOrthographyBS
+  , InOrth(..)
+  , OutOrth(..)
+  , inputOrthNameMap
+  , outputOrthNameMap
+  ) where
+
+import Metamorth.Interaction.Quasi
+
+[metamorth|
+
+language : "Backtrack"
+
+phonemes : "examples/phonemes/backtrack_test.thym"
+
+Backtracker
+  input  : "examples/parsing/backtrack_example.thyp"
+  output : "examples/output/backtrack_example.thyo"
+  suffix : "_bkt"
+  parser-name : "backtrackParser"
+  output-name : "backtrackOutput"
+  unify-branches : off
+  extension : .bkt
+  description : "Test Orthography."
+
+Backtracker2
+  output : "examples/output/backtrack_example2.thyo"
+  suffix : "_bk2"
+  parser-name : "backtrackParser2"
+  output-name : "backtrackOutput2"
+  unify-branches : off
+  extension : .bk2
+  description : "Another Test Orthography."
+
+
+|]
+
+{-
+Umista
+  input  : "parsers/umista.thyp"
+  output : "output/umista.thyo"
+  cli-names : "umista", "ums", "u"
+  suffix : "ums"
+  parser-name : umistaParser -- optional
+  output-name : umistaOutput -- optional
+  unify-paths : off
+
+-}
+

--- a/test/Test/TH/KwakQuasi.hs
+++ b/test/Test/TH/KwakQuasi.hs
@@ -75,3 +75,4 @@ Umista
   unify-paths : off
 
 -}
+

--- a/test/Test/TH/KwakQuasi.hs
+++ b/test/Test/TH/KwakQuasi.hs
@@ -35,6 +35,16 @@ Umista
   extension : .umi
   description : "Orthography developed by the U'mista Cultural Centre."
 
+Umista2  
+  # input  : "examples/parsing/kwakwala_umista.thyp"
+  output : "examples/output/kwakwala_umista_alt.thyo"
+  suffix : "_ums2"
+  # parser-name : "umistaParser2"
+  output-name : "umistaOutput2"
+  # unify-branches : off
+  extension : .umi2
+  description : "Alternate version of U'mista for testing."
+
 
 Grubb
   input  : "examples/parsing/kwakwala_grubb.thyp"
@@ -65,4 +75,3 @@ Umista
   unify-paths : off
 
 -}
-

--- a/test/Test/TH/KwakQuasi.hs
+++ b/test/Test/TH/KwakQuasi.hs
@@ -44,6 +44,14 @@ Grubb
   output-name : "grubbOutput"
   extension : ".grb"
 
+Boas
+  input  : "examples/parsing/kwakwala_boas.thyp"
+  suffix : "_boas"
+  parser-name : "boasParser"
+  extension : ".boas"
+  unify-branches : off
+  description : "Collection of Boas's orthographies."
+
 |]
 
 {-


### PR DESCRIPTION
This PR adds support for "Auto-Off" states to the input parser. These are states that are automatically turned off after any pattern where they aren't explicitly turned on. 

Auto-Off states are useful to provide information about the previous phoneme parsed. For example, if there is an implicit consonant between two vowels, you could do something like this:

```
...

auto state lastVow

====

a : a !lastVow=on
e : e !lastVow=on

...

glt a : @lastVow=on a !lastVow=on
glt e : @lastVow=on e !lastVow=on

...
```

In addition, this PR also improves the QuasiQuoter parsing. Previously, if the user forgot to include a colon/equal sign between a field and its value, the program would compile, but ignore everything in the QuasiQuoter at and after the field in question. Now, it will properly parse otherwise good fields missing a colon/equal sign, but display a warning that it is missing one.
