### PR TITLE
Add (simple) parser lookahead

### DIFF
--- a/examples/output/example_follow_01.thyo
+++ b/examples/output/example_follow_01.thyo
@@ -19,6 +19,7 @@ oo : ʊ
 # aw : a w
 aw : ɒ
 schwa : ə
+u : u
 
 # Testing "follow" stuff
 # aw >palatal_velar  : ɑ

--- a/examples/output/example_follow_02.thyo
+++ b/examples/output/example_follow_02.thyo
@@ -23,6 +23,7 @@ oo : ʊ
 # aw : a w
 aw : ɒ
 schwa : ə
+u : u
 
 # Testing "follow" stuff
 aw >palatal_velar  : ɑ

--- a/examples/output/example_follow_03.thyo
+++ b/examples/output/example_follow_03.thyo
@@ -27,6 +27,7 @@ oo : ʊ
 # aw : a w
 aw : ɒ
 schwa : ə
+u : u
 
 # Testing "follow" stuff
 aw >palatal_velar  : ɑ

--- a/examples/parsing/lookahead_example.thyp
+++ b/examples/parsing/lookahead_example.thyp
@@ -1,0 +1,94 @@
+
+orthography : lookahead
+phoneme set : follow
+
+====
+
+auto state lastVow
+
+state help : helpA helpB helpC
+
+import group alveolar
+
+import group palatal_velar
+
+import group vowel
+
+import trait nasal
+
+import trait example
+
+====
+
+# vowels
+a : a !lastVow=on
+a : æ !lastVow=on
+e : e !lastVow=on
+i : i !lastVow=on
+o : o !lastVow=on
+oo : ʊ !lastVow=on
+oo : o o !lastVow=on
+aw : a w !lastVow=on
+aw : ɒ !lastVow=on
+aw : ɑ !lastVow=on
+schwa : ə !lastVow=on
+schwa : u h !lastVow=on
+
+# Testing things...
+# (These are just examples; they don't make sense.)
+aw : ø >nasal !lastVow=on
+oo : ø >palatal_velar !lastVow=on
+o  : ø >alveolar !lastVow=on
+schwa : ø !lastVow=on 
+
+# Hmm...
+i : y >nasal !lastVow=on
+u : y >alveolar !lastVow=on
+j : y
+
+# labial
+b : b
+p : p
+f : f
+w : w
+v : v
+m : m
+
+# alveolar
+n : n
+d : d
+t : t
+s : s
+l : l
+r : r
+sh : ʃ
+sh : s h
+ch : c h
+ch : t ʃ
+zh : z h
+zh : ʒ
+ts : t s
+ts : c
+dz : d z
+th : t h
+th : θ
+dh : d h
+dh : ð
+dzh : d ʒ
+dzh : d z h
+
+# Thorn
+th : þ 
+th : þ >vowel !help=helpA
+dh : þ >nasal !help=helpC
+dh : þ >b !help=helpB
+dh : þ >v !help=helpB
+
+# palatal/alveolar
+j : j
+k : k
+g : g
+ng : n g
+ng : ŋ
+h : x # to avoid conflicts
+h : h

--- a/examples/parsing/lookahead_example.thyp
+++ b/examples/parsing/lookahead_example.thyp
@@ -46,6 +46,11 @@ i : y >nasal !lastVow=on
 u : y >alveolar !lastVow=on
 j : y
 
+# Double-lookahead
+u : ɵ >i !lastVow=on
+o : ɵ >u !lastVow=on
+schwa : ɵ !lastVow=on
+
 # labial
 b : b
 b : @help=helpA β

--- a/examples/parsing/lookahead_example.thyp
+++ b/examples/parsing/lookahead_example.thyp
@@ -48,6 +48,11 @@ j : y
 
 # labial
 b : b
+b : @help=helpA β
+b : @help=helpB б
+b : @help=helpC ḅ
+
+
 p : p
 f : f
 w : w

--- a/metamorTHysis.cabal
+++ b/metamorTHysis.cabal
@@ -76,6 +76,7 @@ library
       Metamorth.Interpretation.Parser.Parsing.Trie
       Metamorth.Interpretation.Parser.Parsing.Types
       Metamorth.Interpretation.Parser.TH
+      Metamorth.Interpretation.Parser.TH.Lookahead
       Metamorth.Interpretation.Parser.Types
       Metamorth.Interpretation.Phonemes.Parsing
       Metamorth.Interpretation.Phonemes.Parsing.Types

--- a/metamorTHysis.cabal
+++ b/metamorTHysis.cabal
@@ -82,6 +82,7 @@ library
       Metamorth.Interpretation.Phonemes.TH
       Metamorth.Interpretation.Phonemes.TH.Types
       Metamorth.Interpretation.Phonemes.Types
+      Metamorth.Interpretation.Shared.Types
   other-modules:
       Paths_metamorTHysis
   autogen-modules:

--- a/src/Metamorth/Helpers/Map.hs
+++ b/src/Metamorth/Helpers/Map.hs
@@ -9,6 +9,7 @@ module Metamorth.Helpers.Map
   , lookupE
   , forMapFromSet
   , forMapFromSetM
+  , mapKeysMaybe
   ) where
 
 import Data.Functor (($>))
@@ -71,6 +72,17 @@ forMapFromSet st f = sequenceA $ M.fromSet f st
 forMapFromSetM :: (Monad m) => S.Set a -> (a -> m b) -> m (M.Map a b)
 forMapFromSetM st f = sequence $ M.fromSet f st
 
+mapKeysMaybe :: (Ord k, Ord k') => (k -> Maybe k') -> M.Map k a -> M.Map k' a
+mapKeysMaybe f = M.fromList . M.foldrWithKey fr []
+  where
+    fr k x xs = case (f k) of
+      Nothing   -> xs
+      (Just k') -> (k', x) : xs
+
+{-
+mapKeys :: Ord k2 => (k1->k2) -> Map k1 a -> Map k2 a
+mapKeys f = fromList . foldrWithKey (\k x xs -> (f k, x) : xs) []
+-}
 
 {- whoops
 mapMapMaybeWithKey :: (k -> a -> Maybe b) -> M.Map k a -> M.Map k b

--- a/src/Metamorth/Helpers/Parsing.hs
+++ b/src/Metamorth/Helpers/Parsing.hs
@@ -25,6 +25,7 @@ module Metamorth.Helpers.Parsing
   -- * Combinators lifted over `State.StateT`
   , lookAheadS
   , lookAheadS'
+  , lookAheadSX
 
   -- * Combinators lifted over `RWS.RWST`
   , lookAheadRWS
@@ -155,6 +156,17 @@ lookAheadS' :: (State.StateT s AT.Parser a) -> (State.StateT s AT.Parser (a,s))
 lookAheadS' prs = do
   st <- State.get
   lift $ AC.lookAhead (State.runStateT prs st)
+
+-- | Like `lookAheadS`, but modifies the value
+--   of the state before running the parser.
+--   This is useful if you want to modify the
+--   state value when looking ahead, but don't
+--   necessarily want to modify the state in the
+--   non-lookahead section.
+lookAheadSX :: (s -> s) -> (State.StateT s AT.Parser a) -> (State.StateT s AT.Parser a)
+lookAheadSX f prs = do
+  st <- State.get
+  lift $ AC.lookAhead (State.evalStateT prs (f $! st))
 
 -- | Lift `AC.lookAhead` over `RWS.RWST`, returning
 --   the value, state, and writer of the computation.

--- a/src/Metamorth/Helpers/Trie.hs
+++ b/src/Metamorth/Helpers/Trie.hs
@@ -32,6 +32,8 @@ module Metamorth.Helpers.Trie
   , forBranches
   , insertIfEmpty
   , insertMaybeIfEmpty
+  , partitionTrieK
+  , anyTrieKey
   -- , annotateTrie
   -- , annotifyTrie
   -- , setifyTrie
@@ -229,3 +231,21 @@ mapBranches f (TMI.TMap (TMI.Node _ e))
       in  (TMI.TMap (TMI.Node mx' submap'))
       ) e
 -}
+
+-- | Partition this node of a `TM.TMap` based on
+--   the keys of the next nodes. Note that the
+--   value at the head of this `TM.TMap`s. is also at
+--   the head of *both* output `TM.TMap`s.
+partitionTrieK :: (c -> Bool) -> TM.TMap c a -> (TM.TMap c a, TM.TMap c a)
+partitionTrieK fltr (TMI.TMap (TMI.Node mv mp))
+  | (mp1, mp2) <- M.partitionWithKey (\k _ -> fltr k) mp
+  = ( TMI.TMap (TMI.Node mv mp1)
+    , TMI.TMap (TMI.Node mv mp2)
+    )
+
+-- | See if any of the next nodes meet a condition
+anyTrieKey :: (c -> Bool) -> TM.TMap c a -> Bool
+anyTrieKey fltr (TMI.TMap (TMI.Node _mv mp))
+  = any fltr (M.keys mp)
+
+

--- a/src/Metamorth/Interaction/TH.hs
+++ b/src/Metamorth/Interaction/TH.hs
@@ -357,8 +357,17 @@ readOutputFile (fp, eod) = do
 
 getParserData :: FilePath -> PhonemeDatabase -> Text -> ExtraParserDetails -> Q ((([Dec], StaticParserInfo), (Name, Name)), [(Exp, Exp)])
 getParserData fp pdb txt epd = do
-  -- here
-  let eParseRslt = AT.parseOnly parseOrthographyFile txt
+  -- New information needed
+  let pni = makePhonemeInformation pdb
+      aspectSet = M.map (M.keysSet . snd . snd) (pniAspects pni)
+      phoneSet  = M.keysSet $ pniPhones pni
+      
+      traitDict = pdbTraitInformation pdb 
+      -- From Map String (Name, Maybe (Name, Map String Name))
+      -- To   Map String (Maybe (Set String))\
+      traitMaps = fmap (\(_, mb) -> fmap (\(_,mp) -> M.keysSet mp) mb) traitDict
+      
+      eParseRslt = AT.parseOnly (parseOrthographyFileNew (M.keysSet (pdbGroupMemberFuncs pdb)) traitMaps aspectSet phoneSet) txt
       newNameStr = epdParserName epd
   ((dcs1, spi, funcNom), typeNom) <- case eParseRslt of
     (Left err) -> fail $ "Couldn't parse input file \"" ++ fp ++ "\": " ++ err

--- a/src/Metamorth/Interaction/TH.hs
+++ b/src/Metamorth/Interaction/TH.hs
@@ -366,7 +366,8 @@ getParserData fp pdb txt epd = do
       -- From Map String (Name, Maybe (Name, Map String Name))
       -- To   Map String (Maybe (Set String))\
       traitMaps = fmap (\(_, mb) -> fmap (\(_,mp) -> M.keysSet mp) mb) traitDict
-      
+
+      -- (HeaderData, ParserParsingState, [String], [String])
       eParseRslt = AT.parseOnly (parseOrthographyFileNew (M.keysSet (pdbGroupMemberFuncs pdb)) traitMaps aspectSet phoneSet) txt
       newNameStr = epdParserName epd
   ((dcs1, spi, funcNom), typeNom) <- case eParseRslt of
@@ -390,6 +391,9 @@ getParserData fp pdb txt epd = do
             (pdbMkMaj pdb)
             (pdbMkMin pdb)
             (pdbWordTypeNames pdb)
+            (pniAspects pni)
+            (pdbTraitInformation pdb)
+            (pdbGroupMemberFuncs pdb)
             (pps)
             (epdParserOptions epd)
       return (prs, hdOrthName hdr)

--- a/src/Metamorth/Interpretation/Output/Parsing.hs
+++ b/src/Metamorth/Interpretation/Output/Parsing.hs
@@ -50,6 +50,8 @@ import Data.Set        qualified as S
 -- A lot of the code here is taken from
 -- "Metamorth.Interpretation.Parser.Parsing".
 
+import Metamorth.Interpretation.Shared.Types
+
 ----------------------------------------------------------------
 -- Main Parser
 ----------------------------------------------------------------
@@ -245,29 +247,30 @@ getImportS_ :: OutputParser ()
 getImportS_ = void getImportS
 
 -- | Import a trait/group/aspect from the phoneme file.
-getImport :: AT.Parser ImportProperty
-getImport = do
-  _ <- "import"
-  skipHoriz1
-  getAspect <|> getTrait <|> getGroup
-
-getAspect :: AT.Parser ImportProperty
-getAspect = do
-  _ <- "aspect"
-  skipHoriz1
-  ImportAspect . T.unpack <$> takeIdentifier isAlpha isFollowId
-
-getTrait :: AT.Parser ImportProperty
-getTrait = do
-  _ <- "trait"
-  skipHoriz1
-  ImportTrait . T.unpack <$> takeIdentifier isAlpha isFollowId
-
-getGroup :: AT.Parser ImportProperty
-getGroup = do
-  _ <- "group"
-  skipHoriz1
-  ImportGroup . T.unpack <$> takeIdentifier isAlpha isFollowId
+--   Moved to Metamorth.Interpretation.Shared.Types
+-- getImport :: AT.Parser ImportProperty
+-- getImport = do
+--   _ <- "import"
+--   skipHoriz1
+--   getAspect <|> getTrait <|> getGroup
+-- 
+-- getAspect :: AT.Parser ImportProperty
+-- getAspect = do
+--   _ <- "aspect"
+--   skipHoriz1
+--   ImportAspect . T.unpack <$> takeIdentifier isAlpha isFollowId
+-- 
+-- getTrait :: AT.Parser ImportProperty
+-- getTrait = do
+--   _ <- "trait"
+--   skipHoriz1
+--   ImportTrait . T.unpack <$> takeIdentifier isAlpha isFollowId
+-- 
+-- getGroup :: AT.Parser ImportProperty
+-- getGroup = do
+--   _ <- "group"
+--   skipHoriz1
+--   ImportGroup . T.unpack <$> takeIdentifier isAlpha isFollowId
 
 ----------------------------------------------------------------
 -- State Info Parsers

--- a/src/Metamorth/Interpretation/Output/Parsing/Types.hs
+++ b/src/Metamorth/Interpretation/Output/Parsing/Types.hs
@@ -43,6 +43,8 @@ import Metamorth.Helpers.Char
 import Metamorth.Interpretation.Output.Types
 import Metamorth.Interpretation.Output.Types.Alt
 
+import Metamorth.Interpretation.Shared.Types (ImportProperty(..))
+
 --------------------------------
 -- Types for Parsing
 
@@ -123,11 +125,12 @@ runOnPhoneme str = local (const str)
 
 -- | Data type for declarations of the form
 --   `import (aspect | group | trait) prop_name`.
-data ImportProperty
-  = ImportAspect String
-  | ImportGroup  String
-  | ImportTrait  String
-  deriving (Show, Eq, Ord)
+-- Moved to "Metamorth.Interpretation.Shared.Types"
+-- data ImportProperty
+--   = ImportAspect String
+--   | ImportGroup  String
+--   | ImportTrait  String
+--   deriving (Show, Eq, Ord)
 
 -- | The parsed values on the left-hand side
 --   of a phoneme pattern.

--- a/src/Metamorth/Interpretation/Output/Parsing/Types.hs
+++ b/src/Metamorth/Interpretation/Output/Parsing/Types.hs
@@ -152,12 +152,12 @@ data PhonePatternRaw
 pattern PhoneFollowR :: PhonePatternRaw
 pattern PhoneFollowR <- (convertFollow -> (Just _))
 
--- | Fast way to match a phoneme patterns that
+-- | Fast way to match phoneme patterns that
 --   have to go at the start of an expression.
 pattern PhoneStartR :: PhonePatternRaw
 pattern PhoneStartR <- ((\x -> x == PhoneAtStartR || x == PhoneNotStartR) -> True)
 
--- | Fast way to match a phoneme patterns that
+-- | Fast way to match phoneme patterns that
 --   have to go at the end of an expression.
 pattern PhoneEndR :: PhonePatternRaw
 pattern PhoneEndR <- ((\x -> x == PhoneAtEndR || x == PhoneNotEndR) -> True)

--- a/src/Metamorth/Interpretation/Parser/TH.hs
+++ b/src/Metamorth/Interpretation/Parser/TH.hs
@@ -1767,6 +1767,15 @@ modifyStateExps  sdict mods = do
       lamb = LamE [VarP xvar] (RecUpdE (VarE xvar) fieldExps)
   return $ \expr -> infixCont (AppE (VarE 'State.modify') lamb) expr
 
+-- | For use when modifying the state before a
+--   lookahead. This creates a simple Lambda
+--   expression.
+makeModifyStatesLA :: M.Map String (Name, Maybe (Name, M.Map String Name)) -> [ModifyStateX] -> Either [String] Exp
+makeModifyStatesLA _sdict [] = Right (VarE 'id)
+makeModifyStatesLA  sdict mods = do
+  fieldExps <- liftEitherList (map (modifyStateExp sdict) mods)
+  let xvar = mkName "x"
+  return $ LamE [VarP xvar] (RecUpdE (VarE xvar) fieldExps)
 
 ----------------------------------------------------------------
 -- Pre-Constructed Expressions

--- a/src/Metamorth/Interpretation/Parser/TH/Lookahead.hs
+++ b/src/Metamorth/Interpretation/Parser/TH/Lookahead.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Metamorth.Interpretation.Parser.TH.Lookahead
+  ( createLookahead
+  , createMultiLookahead
+  ) where
+
+import Data.Attoparsec.Text qualified as AT
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Syntax
+
+import Metamorth.Helpers.Parsing
+
+import Metamorth.Interpretation.Parser.Types
+
+import Data.List.NonEmpty qualified as NE
+import Metamorth.Helpers.TH
+
+
+createLookahead :: (Quote q) => {-[ModifyStateX]-} Exp -> Name -> (Exp -> Exp) -> Exp -> q Exp
+createLookahead stModLamb funcName rsltCheck rslt = do
+  -- let x = 0
+  zNom <- newName "z"
+  okay <- 
+    [| do
+         -- hmm...
+         { newRslt <- lookAheadSX $(pure stModLamb) $ do
+           { $(pure $ VarP zNom) <- NE.head <$> $(pure $ VarE funcName) 
+           ; return $ $(pure $ rsltCheck (VarE zNom))
+           }
+         ; if newRslt then (return $(pure $ rslt)) else (fail "Failed a lookahead")
+         }
+    |]
+  return okay
+
+createMultiLookahead :: (Quote q) => {-[ModifyStateX]-} Exp -> Name -> [(Exp -> Exp, Exp)] -> Maybe Exp -> q Exp
+createMultiLookahead stModLamb funcName rsltChecks otherRslt = do
+  -- let x = 0
+  zNom <- newName "z"
+  okay <- 
+    [| do
+         -- hmm...
+         -- Don't need the Bool for the casedness, since we're starting
+         -- a new phoneme. The Bool for casedness only applies when
+         -- running a parser midway through parsing a single phoneme.
+         { $(pure $ VarP zNom) <- lookAheadSX $(pure stModLamb) $ NE.head <$> $(pure $ VarE funcName) 
+         ; $(pure $ MultiIfE (ifBlocks zNom))
+         }
+    |]
+  return ()
+  return okay
+  where
+    otherRslt'
+      | (Just oRslt) <- otherRslt
+      = AppE (VarE 'return) oRslt
+      -- = [| return $(pure oRslt) |]
+      | otherwise
+      =  AppE (VarE 'fail) (LitE (StringL "Could not find a lookahead."))
+      -- = [| fail "Could not find a lookahead." |]
+    ifBlocks' :: Name -> [(Guard, Exp)]
+    ifBlocks' nom = forMap rsltChecks $ \(expFunc, outp) ->
+      ( NormalG $ expFunc (VarE nom)
+      , AppE (VarE 'return) outp
+      )
+    ifBlocks :: Name -> [(Guard, Exp)]
+    ifBlocks nom = ifBlocks' nom ++ [(NormalG $ VarE 'otherwise, otherRslt')]
+    
+
+
+-- MultiIfE [(Guard, Exp)]
+-- data Guard = NormalG Exp | PatG [Stmt]
+
+{-
+lookAheadSX :: (s -> s) -> (State.StateT s AT.Parser a) -> (State.StateT s AT.Parser a)
+lookAheadSX f prs = do
+  st <- State.get
+  lift $ AC.lookAhead (State.evalStateT prs (f $! st))
+-}

--- a/src/Metamorth/Interpretation/Parser/TH/Lookahead.hs
+++ b/src/Metamorth/Interpretation/Parser/TH/Lookahead.hs
@@ -3,7 +3,11 @@
 module Metamorth.Interpretation.Parser.TH.Lookahead
   ( createLookahead
   , createMultiLookahead
+  , createMultiLookahead2
   ) where
+
+import Control.Applicative
+import Control.Monad
 
 import Data.Attoparsec.Text qualified as AT
 
@@ -15,8 +19,11 @@ import Metamorth.Helpers.Parsing
 import Metamorth.Interpretation.Parser.Types
 
 import Data.List.NonEmpty qualified as NE
+import Data.List.NonEmpty (NonEmpty(..))
+
 import Metamorth.Helpers.TH
 
+import Control.Monad.Trans.State.Strict qualified as St
 
 createLookahead :: (Quote q) => {-[ModifyStateX]-} Exp -> Name -> (Exp -> Exp) -> Exp -> q Exp
 createLookahead stModLamb funcName rsltCheck rslt = do
@@ -53,7 +60,9 @@ createMultiLookahead stModLamb funcName rsltChecks otherRslt = do
   where
     otherRslt'
       | (Just oRslt) <- otherRslt
-      = AppE (VarE 'return) oRslt
+      = if (stModLamb == (VarE 'id))
+        then AppE (VarE 'return) oRslt
+        else InfixE (Just (AppE (VarE 'St.modify') stModLamb)) (VarE '(>>)) (Just (AppE (VarE 'return) oRslt))
       -- = [| return $(pure oRslt) |]
       | otherwise
       =  AppE (VarE 'fail) (LitE (StringL "Could not find a lookahead."))
@@ -66,10 +75,32 @@ createMultiLookahead stModLamb funcName rsltChecks otherRslt = do
     ifBlocks :: Name -> [(Guard, Exp)]
     ifBlocks nom = ifBlocks' nom ++ [(NormalG $ VarE 'otherwise, otherRslt')]
     
-
+-- Warning: Needs to modify state!
+-- Also: What if there are multiple lookaheads that
+-- make different moddifications to the state(s)?
 
 -- MultiIfE [(Guard, Exp)]
 -- data Guard = NormalG Exp | PatG [Stmt]
+
+-- | For use when you have multiple possible
+--   lookaheads that have different state modifications.
+createMultiLookahead2 :: (Quote q) => Name -> [(Exp, [(Exp -> Exp, Exp)])] -> Maybe (Exp, Exp) -> q Exp
+createMultiLookahead2 funcName modCases otherRslt = do
+  rsltList <- forM modCases $ \(stModLamb, rsltChecks) -> 
+    createMultiLookahead stModLamb funcName rsltChecks Nothing
+  return $ intersperseInfixRE (VarE '(<|>)) (snocNE rsltList otherRslt')
+  where
+    otherRslt'
+      | Just (oRslt, stMod) <- otherRslt
+      = if (stMod == (VarE 'id))
+        then AppE (VarE 'return) oRslt
+        else InfixE (Just (AppE (VarE 'St.modify') stMod)) (VarE '(>>)) (Just (AppE (VarE 'return) oRslt))
+      | otherwise
+      =  AppE (VarE 'fail) (LitE (StringL "Could not find a lookahead."))
+
+snocNE :: [a] -> a -> NonEmpty a
+snocNE []     y = y :| []
+snocNE (x:xs) y = x :| (xs ++ [y])
 
 {-
 lookAheadSX :: (s -> s) -> (State.StateT s AT.Parser a) -> (State.StateT s AT.Parser a)
@@ -77,3 +108,6 @@ lookAheadSX f prs = do
   st <- State.get
   lift $ AC.lookAhead (State.evalStateT prs (f $! st))
 -}
+
+-- intersperseInfixRE (VarE '(<|>))
+

--- a/src/Metamorth/Interpretation/Parser/Types.hs
+++ b/src/Metamorth/Interpretation/Parser/Types.hs
@@ -22,6 +22,8 @@ module Metamorth.Interpretation.Parser.Types
   , RawPhonemePattern(..)
   , CharPatternRaw(..)
   , FollowPattern(..)
+  , isFollowPat
+  , getFollowPat
   ) where
 
 import Data.Bifunctor
@@ -110,6 +112,14 @@ data CharPatternF b
   | NotEnd                  -- ^ NOT the end of a word.
   | FollowPat FollowPattern -- ^ A `FollowPattern`
   deriving (Show, Eq)
+
+isFollowPat :: CharPattern -> Bool
+isFollowPat (FollowPat _) = True
+isFollowPat _ = False
+
+getFollowPat :: CharPattern -> Maybe FollowPattern
+getFollowPat (FollowPat x) = Just x
+getFollowPat _ = Nothing
 
 -- Make (CharPatternF (Down b)) an instance of `Ord` so that
 -- (CharPatternF b) has something to derive via. Also make this

--- a/src/Metamorth/Interpretation/Parser/Types.hs
+++ b/src/Metamorth/Interpretation/Parser/Types.hs
@@ -21,6 +21,7 @@ module Metamorth.Interpretation.Parser.Types
   
   , RawPhonemePattern(..)
   , CharPatternRaw(..)
+  , FollowPattern(..)
   ) where
 
 import Data.Bifunctor
@@ -66,6 +67,16 @@ data CharPatternRaw
   | NotEndR           -- ^ NOT the end of a word.
   | ValStateR String (Either String Bool) -- ^ Check that the state is a certain value.
   | SetStateR String (Either String Bool) -- ^ Set the state to a certain value.
+  | FollowPatR FollowPattern
+  deriving (Show, Eq, Ord)
+
+data FollowPattern
+  = FollowAspect   String
+  | FollowAspectAt String String
+  | FollowTrait    String
+  | FollowTraitAt  String String
+  | FollowGroup    String
+  | FollowPhone    String
   deriving (Show, Eq, Ord)
 
 isStateR :: CharPatternRaw -> Bool
@@ -90,13 +101,14 @@ type CharPattern = CharPatternF [CheckStateX]
 
 -- | The "internal" version of `CharPattern`.
 data CharPatternF b
-  = PlainChar   b Char   -- ^ A single `Char`.
-  | CharOptCase b Char   -- ^ Any case of a `Char`.
-  | CharClass   b String -- ^ Any member of a class from the header.
-  | WordStart            -- ^ The start of a word.
-  | WordEnd              -- ^ The end of a word.
-  | NotStart             -- ^ NOT the start of a word.
-  | NotEnd               -- ^ NOT the end of a word.
+  = PlainChar   b Char      -- ^ A single `Char`.
+  | CharOptCase b Char      -- ^ Any case of a `Char`.
+  | CharClass   b String    -- ^ Any member of a class from the header.
+  | WordStart               -- ^ The start of a word.
+  | WordEnd                 -- ^ The end of a word.
+  | NotStart                -- ^ NOT the start of a word.
+  | NotEnd                  -- ^ NOT the end of a word.
+  | FollowPat FollowPattern -- ^ A `FollowPattern`
   deriving (Show, Eq)
 
 -- Make (CharPatternF (Down b)) an instance of `Ord` so that
@@ -252,6 +264,7 @@ startPatR _ = False
 endPatR :: CharPatternRaw -> Bool
 endPatR WordEndR = True
 endPatR NotEndR  = True
+endPatR (FollowPatR _) = True
 endPatR _ = False
 
 -- Note that NotStart must occur at the beginning of
@@ -296,8 +309,8 @@ validCharPatternE [] = Left "Can't have an empty pattern."
 validCharPatternE ((PlainCharR _):xs) = validCharPatternE' xs
 validCharPatternE ((CharClassR _):xs) = validCharPatternE' xs
 validCharPatternE [x]    | (startPatR x) = Left "Can't have a pattern with just a [not-]start-word mark."
-validCharPatternE [x,y]  | (startPatR x && endPatR y) = Left "Can't have a pattern that consists of just [not-]start and [not-]end mark(s)"
-validCharPatternE (x:xs) | (endPatR x) = Left "Can't start a pattern with a [not-]word-end mark."
+validCharPatternE [x,y]  | (startPatR x && endPatR y) = Left "Can't have a pattern that consists of just [not-]start and [not-]end/follow mark(s)"
+validCharPatternE (x:xs) | (endPatR x) = Left "Can't start a pattern with a [not-]word-end or follow mark."
 validCharPatternE (WordStartR:xs) = validCharPatternE' xs
 validCharPatternE (NotStartR :xs) = validCharPatternE' xs
 validCharPatternE (x:_)  
@@ -312,7 +325,7 @@ validCharPatternE' ((CharClassR _):xs) = validCharPatternE' xs
 validCharPatternE' [x] | (endPatR x) = Right ()
 validCharPatternE' (x:_) 
   | (startPatR x) = Left "Can't have a [not-]word-start mark in the middle of a pattern."
-  | (endPatR   x) = Left "Can't have a [not-]word-end mark in the middle of a pattern."
+  | (endPatR   x) = Left "Can't have a [not-]word-end/follow mark in the middle of a pattern."
   | (isStateR  x) = Left "State-patterns should have been filtered out by this point."
   | otherwise     = Left "Some type of error happened in validateCharPatternE'."
 
@@ -332,8 +345,8 @@ validateCharPatternEX ((PlainCharR x):xs) = do
   ((PlainChar [] x):) <$> validateCharPatternE' xs
 validateCharPatternEX ((CharClassR x):xs) = ((CharClass [] x):) <$> validateCharPatternE' xs
 validateCharPatternEX [x]    | (startPatR x) = lift $ Left "Can't have a pattern with just a [not-]start-word mark."
-validateCharPatternEX [x,y]  | (startPatR x && endPatR y) = lift $ Left "Can't have a pattern that consists of just [not-]start and [not-]end mark(s)"
-validateCharPatternEX (x:_)  | (endPatR x) = lift $ Left "Can't start a pattern with a [not-]word-end mark."
+validateCharPatternEX [x,y]  | (startPatR x && endPatR y) = lift $ Left "Can't have a pattern that consists of just [not-]start and [not-]end/follow mark(s)"
+validateCharPatternEX (x:_)  | (endPatR x) = lift $ Left "Can't start a pattern with a [not-]word-end/follow mark."
 validateCharPatternEX (WordStartR:xs) = (WordStart:) <$> validateCharPatternE' xs
 validateCharPatternEX (NotStartR :xs) = (NotStart :) <$> validateCharPatternE' xs
 validateCharPatternEX (x:_)  | isStateR x = lift $ Left "State-patterns should have been filtered out by this point."
@@ -353,6 +366,7 @@ validateCharPatternE' ((PlainCharR x):xs) = do
 validateCharPatternE' ((CharClassR x):xs) = ((CharClass [] x):) <$> validateCharPatternE' xs
 validateCharPatternE' [WordEndR] = return [WordEnd]
 validateCharPatternE' [NotEndR]  = return [NotEnd]
+validateCharPatternE' [(FollowPatR fpat)] = return [FollowPat fpat]
 validateCharPatternE' (x:_) 
   | (startPatR x) = lift $ Left "Can't have a [not-]word-start mark in the middle of a pattern."
   | (endPatR   x) = lift $ Left "Can't have a [not-]word-end mark in the middle of a pattern."
@@ -393,9 +407,10 @@ validateCharPatternZ' ((PlainCharR x):xs) = do
 validateCharPatternZ' ((CharClassR x):xs) = ((CharClass [] x):) <$> validateCharPatternZ' xs
 validateCharPatternZ' [WordEndR] = return [WordEnd]
 validateCharPatternZ' [NotEndR]  = return [NotEnd]
+validateCharPatternZ' [FollowPatR fpat] = return [FollowPat fpat]
 validateCharPatternZ' (x:_) 
   | (startPatR x) = lift $ Left "Can't have a [not-]word-start mark in the middle of a pattern."
-  | (endPatR   x) = lift $ Left "Can't have a [not-]word-end mark in the middle of a pattern."
+  | (endPatR   x) = lift $ Left "Can't have a [not-]word-end/follow mark in the middle of a pattern."
   | (isStateR  x) = lift $ Left "State-patterns should have been filtered out by this point."
   | otherwise     = lift $ Left "Some type of error happened when validating a CharPatternRaw."
 

--- a/src/Metamorth/Interpretation/Phonemes/TH.hs
+++ b/src/Metamorth/Interpretation/Phonemes/TH.hs
@@ -156,10 +156,10 @@ data PhonemeDatabase = PhonemeDatabase
   , pdbWordTypeNames  :: (Name, (Name, Name))
   -- | Functions for checking membership in a group.
   , pdbGroupMemberFuncs :: M.Map String Name
-  -- | Functions for checking whether a function has
+  -- | Functions for checking whether a `String` is
   --   a trait, and whether that trait is a value trait
-  --   (@True@) or a boolean trait (@False@).
-  , pdbTraitInformation :: M.Map String (Name, (Maybe (Name, M.Map String Name)))
+  --   (@Just ...@) or a boolean trait (@Nothing@).
+  , pdbTraitInformation :: M.Map String (Name, Maybe (Name, M.Map String Name))
   -- | Make an uncased expression an upper-case expression.
   , pdbMkMaj :: Exp -> Exp
   -- | Make an uncased expression a  lower-case expression.

--- a/src/Metamorth/Interpretation/Shared/Types.hs
+++ b/src/Metamorth/Interpretation/Shared/Types.hs
@@ -1,0 +1,46 @@
+module Metamorth.Interpretation.Shared.Types
+  ( ImportProperty(..)
+  , getImport
+  ) where
+
+import Data.Attoparsec.Text qualified as AT
+
+import Metamorth.Helpers.Parsing
+
+import Data.Text qualified as T
+
+import Control.Applicative
+
+import Data.Char
+
+-- | Data type for declarations of the form
+--   `import (aspect | group | trait) prop_name`.
+data ImportProperty
+  = ImportAspect String
+  | ImportGroup  String
+  | ImportTrait  String
+  deriving (Show, Eq, Ord)
+
+getImport :: AT.Parser ImportProperty
+getImport = do
+  _ <- "import"
+  skipHoriz1
+  getAspect <|> getTrait <|> getGroup
+
+getAspect :: AT.Parser ImportProperty
+getAspect = do
+  _ <- "aspect"
+  skipHoriz1
+  ImportAspect . T.unpack <$> takeIdentifier isAlpha isFollowId
+
+getTrait :: AT.Parser ImportProperty
+getTrait = do
+  _ <- "trait"
+  skipHoriz1
+  ImportTrait . T.unpack <$> takeIdentifier isAlpha isFollowId
+
+getGroup :: AT.Parser ImportProperty
+getGroup = do
+  _ <- "group"
+  skipHoriz1
+  ImportGroup . T.unpack <$> takeIdentifier isAlpha isFollowId

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -14,8 +14,6 @@ import Test.TH.Backtrack qualified as Back
 
 import Test.TH.KwakQuasi qualified as KwakQ
 
-import System.IO
-
 import Data.Text qualified as T
 import Data.Text.Lazy (toStrict)
 import Data.Text.Lazy.Encoding qualified as TLE
@@ -34,6 +32,7 @@ import System.IO
 main :: IO ()
 main = do
   hSetEncoding stdout utf8
+  hSetEncoding stderr utf8
   putStrLn "Parsing \"ᓄᓇᑦᓯᐊᕗᑦ\":"
   print $ AT.parseOnly theActualParser "ᓄᓇᑦᓯᐊᕗᑦ"
   putStrLn "Parsing longer text:"
@@ -157,6 +156,12 @@ main = do
     (Left err) -> putStrLn $ "Error: " ++ err
     (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
 
+  putStrLn "Testing input lookahead..."
+  let look2 = TLE.decodeUtf8 <$> Fol.convertOrthographyBS Fol.InLookahead Fol.OutFollowA lookAheadTest2
+  case look2 of
+    (Left err) -> putStrLn $ "Error: " ++ err
+    (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
+
 
 
 
@@ -194,7 +199,9 @@ backTest1 = "tough tougra" --
 lookAheadTest1 :: T.Text
 lookAheadTest1 = "þa þna þøn þøjþvþ ød"
 
--- hmm... ...
+lookAheadTest2 :: T.Text
+lookAheadTest2 = "þaβ þбa þnaḅ"
+
 
 {-
    b : example=exam1

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -150,6 +150,13 @@ main = do
   case back1 of
     (Left err) -> putStrLn $ "Error: " ++ err
     (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
+  
+  putStrLn "Testing input lookahead..."
+  let look1 = TLE.decodeUtf8 <$> Fol.convertOrthographyBS Fol.InLookahead Fol.OutFollowA lookAheadTest1
+  case look1 of
+    (Left err) -> putStrLn $ "Error: " ++ err
+    (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
+
 
 
 
@@ -183,6 +190,9 @@ autoTest2 = "eh'eh'a gwa'um'i" --
 
 backTest1 :: T.Text
 backTest1 = "tough tougra" -- 
+
+lookAheadTest1 :: T.Text
+lookAheadTest1 = "þa þna þøn þøjþvþ ød"
 
 -- hmm... ...
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -162,7 +162,11 @@ main = do
     (Left err) -> putStrLn $ "Error: " ++ err
     (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
 
-
+  putStrLn "Testing input lookahead..."
+  let look3 = TLE.decodeUtf8 <$> Fol.convertOrthographyBS Fol.InLookahead Fol.OutFollowA lookAheadTest3
+  case look3 of
+    (Left err) -> putStrLn $ "Error: " ++ err
+    (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
 
 
 
@@ -202,6 +206,8 @@ lookAheadTest1 = "þa þna þøn þøjþvþ ød"
 lookAheadTest2 :: T.Text
 lookAheadTest2 = "þaβ þбa þnaḅ"
 
+lookAheadTest3 :: T.Text
+lookAheadTest3 = "ɵin ɵyn ɵyd ɵyg"
 
 {-
    b : example=exam1

--- a/test/Test/TH/Following.hs
+++ b/test/Test/TH/Following.hs
@@ -18,6 +18,7 @@ import Metamorth.Interpretation.Parser.TH (ParserOptions(..))
 declareFullParsers 
   "examples/phonemes/example_follow.thym"
   [ ("examples/parsing/example_follow_01.thyp", (defExtraParserDetails "_f01") {epdParserName = "follow1Parser", epdOtherNames = ["f1"]} )
+  , ("examples/parsing/lookahead_example.thyp", (defExtraParserDetails "_lah") {epdParserName = "followLParser", epdOtherNames = ["la"]} )
   ]
   [ ("examples/output/example_follow_01.thyo", defExtraOutputDetails {eodSuffix = "_f01out", eodOutputName = "follow1Output", eodOtherNames = ["f1"]}) 
   , ("examples/output/example_follow_02.thyo", defExtraOutputDetails {eodSuffix = "_f02out", eodOutputName = "follow2Output", eodOtherNames = ["f2"]}) 


### PR DESCRIPTION
This adds a simple version of lookahead to the input parser, similar to the lookahead from the output generator. At the moment, it can only lookahead one phoneme and can only check whether a phoneme is a member of a group, has a certain trait/aspect, or is a specific phoneme. It can't even check for **not** being a member of a group, etc...

I may improve the capabilities in the future; see #7 for possible future features.