### PR TITLE
Add Improved Parser Lookahead

### DIFF
--- a/examples/output/example_follow_01.thyo
+++ b/examples/output/example_follow_01.thyo
@@ -27,7 +27,7 @@ u : u
 aw >g : ɑ
 aw >h : ɑ
 # aw >j : ɑ
-a >sh : æ
+a >(sh|dz|dh) : æ
 
 # labial
 b : b

--- a/examples/output/lookahead_example_01.thyo
+++ b/examples/output/lookahead_example_01.thyo
@@ -1,0 +1,71 @@
+
+name : lookahead
+
+default case : /at
+
+====
+
+# no classes/states
+
+import group alveolar
+
+import group palatal_velar
+
+import trait nasal
+
+import trait example
+
+====
+
+# vowels
+a : a
+e : e
+i : i
+o : o
+oo : ʊ
+# oo : o o
+# aw : a w
+aw : ɒ
+schwa : ə
+u : u
+
+# Testing "follow" stuff
+aw                 : ɑ
+aw >(sh|ch|zh|ts|dz) : ɒ
+a  >alveolar       : æ
+a  >(b|p|m|n|r)    : ɐ
+i  >nasal          : ɪ
+schwa >example     : ɵ
+e >example=exam1   : é
+e >example=exam2   : è
+
+# labial
+b : b
+p : p
+f : f
+w : w
+v : v
+m : m
+
+# alveolar
+n : n
+d : d
+t : t
+s : s
+l : l
+r : r
+sh : ʃ
+ch : t ʃ
+zh : ʒ
+ts : c
+dz : d z
+th : θ
+dh : ð
+dzh : d ʒ
+
+# palatal/alveolar
+j : j
+k : k
+g : g
+ng : ŋ
+h : x # to avoid conflicts

--- a/examples/parsing/lookahead_example.thyp
+++ b/examples/parsing/lookahead_example.thyp
@@ -91,8 +91,9 @@ dzh : d z h
 th : þ 
 th : þ >vowel !help=helpA
 dh : þ >nasal !help=helpC
-dh : þ >b !help=helpB
-dh : þ >v !help=helpB
+dh : þ >(b|v|r|l) !help=helpB
+# dh : þ >b !help=helpB
+# dh : þ >v !help=helpB
 
 # palatal/alveolar
 j : j

--- a/metamorTHysis.cabal
+++ b/metamorTHysis.cabal
@@ -73,6 +73,7 @@ library
       Metamorth.Interpretation.Output.Types.Alt
       Metamorth.Interpretation.Output.Types.Interact
       Metamorth.Interpretation.Parser.Parsing
+      Metamorth.Interpretation.Parser.Parsing.Boolean
       Metamorth.Interpretation.Parser.Parsing.Trie
       Metamorth.Interpretation.Parser.Parsing.Types
       Metamorth.Interpretation.Parser.TH

--- a/metamorTHysis.cabal
+++ b/metamorTHysis.cabal
@@ -74,6 +74,7 @@ library
       Metamorth.Interpretation.Output.Types.Interact
       Metamorth.Interpretation.Parser.Parsing
       Metamorth.Interpretation.Parser.Parsing.Boolean
+      Metamorth.Interpretation.Parser.Parsing.Expr
       Metamorth.Interpretation.Parser.Parsing.Trie
       Metamorth.Interpretation.Parser.Parsing.Types
       Metamorth.Interpretation.Parser.TH
@@ -107,6 +108,7 @@ library
     , bytestring
     , containers
     , directory
+    , parser-combinators
     , template-haskell
     , text
     , th-lego
@@ -140,6 +142,7 @@ executable metamorTHysis-exe
     , containers
     , directory
     , metamorTHysis
+    , parser-combinators
     , template-haskell
     , text
     , th-lego
@@ -185,6 +188,7 @@ test-suite metamorTHysis-test
     , containers
     , directory
     , metamorTHysis
+    , parser-combinators
     , template-haskell
     , text
     , th-lego

--- a/package.yaml
+++ b/package.yaml
@@ -35,6 +35,7 @@ dependencies:
 - bytestring
 - containers
 - directory
+- parser-combinators
 - template-haskell
 - text
 - th-lego

--- a/src/Metamorth/Interpretation/Output/Types.hs
+++ b/src/Metamorth/Interpretation/Output/Types.hs
@@ -41,6 +41,8 @@ import Data.Trie.Map qualified as TM
 
 import Metamorth.Helpers.Ord
 
+import Metamorth.Interpretation.Parser.Parsing.Boolean
+
 data OutputPattern = OutputPattern
   { opCharPattern  :: CharPattern
   , opCasedness    :: OutputCase
@@ -113,7 +115,7 @@ data CaseApply
 -- for more info on this.
 -- | The pattern of Phonemes on the left-hand-side
 --   of a pattern.
-type PhonePattern = PhonePatternF [CheckStateX] [PhoneFollow]
+type PhonePattern = PhonePatternF [CheckStateX] [Boolean2 PhoneFollow]
 {-# COMPLETE PhonemeName, PhoneAtStart, PhoneNotStart, PhoneAtEnd, PhoneNotEnd, PhoneFollow #-}
 
 pattern PhonemeName :: [CheckStateX] -> PhoneName -> PhonePattern
@@ -126,7 +128,7 @@ pattern PhoneAtEnd :: PhonePattern
 pattern PhoneAtEnd = PhoneAtEndX
 pattern PhoneNotEnd :: PhonePattern
 pattern PhoneNotEnd = PhoneNotEndX
-pattern PhoneFollow :: [PhoneFollow] -> PhonePattern
+pattern PhoneFollow :: [Boolean2 PhoneFollow] -> PhonePattern
 pattern PhoneFollow fols = PhoneFollowX fols
 
 -- | The pattern of Phonemes on the left-hand-side

--- a/src/Metamorth/Interpretation/Output/Types/Alt.hs
+++ b/src/Metamorth/Interpretation/Output/Types/Alt.hs
@@ -53,6 +53,8 @@ import Metamorth.Helpers.Ord
 
 import Metamorth.Interpretation.Output.Types
 
+import Metamorth.Interpretation.Parser.Parsing.Boolean
+
 -- | Alternate form of `PhonePatternX` that
 --   instead puts state and follow data into
 --   the value instead of the key.
@@ -69,7 +71,7 @@ data PhoneResultActionX
   | PRModifyState  ModifyStateX
   | PRAtEnd
   | PRNotEnd
-  | PRCheckNext PhoneFollow
+  | PRCheckNext (Boolean2 PhoneFollow)
   deriving (Show, Eq, Ord)
 
 isConfirmState :: PhoneResultActionX -> Bool
@@ -116,7 +118,7 @@ partNotEnds = partitionMap $ \case
   PRNotEnd -> Just ()
   _ -> Nothing
 
-partCheckNexts :: [PhoneResultActionX] -> ([PhoneFollow], [PhoneResultActionX])
+partCheckNexts :: [PhoneResultActionX] -> ([Boolean2 PhoneFollow], [PhoneResultActionX])
 partCheckNexts = partitionMap $ \case
   (PRCheckNext cs) -> Just cs
   _ -> Nothing

--- a/src/Metamorth/Interpretation/Parser/Parsing.hs
+++ b/src/Metamorth/Interpretation/Parser/Parsing.hs
@@ -30,6 +30,7 @@ import Metamorth.Helpers.Parsing
 
 
 import Metamorth.Interpretation.Parser.Parsing.Boolean
+import Metamorth.Interpretation.Parser.Parsing.Expr
 import Metamorth.Interpretation.Parser.Parsing.Types
 import Metamorth.Interpretation.Parser.Types
 
@@ -678,7 +679,16 @@ parseNextCheck = do
   return (T.unpack strProp, T.unpack <$> strVal)
 
 parseNextCheckB :: AT.Parser (Boolean2 (String, Maybe String))
-parseNextCheckB = PlainB2 <$> parseNextCheck
+parseNextCheckB  = do
+  _ <- AT.char '>'
+  skipHoriz
+  parseBooleanExpr $ do
+    strProp <- takeIdentifier isAlpha isFollowId
+    strVal <- optional $ do
+      _ <- AT.char '='
+      takeIdentifier isAlpha isFollowId
+    return (T.unpack strProp, T.unpack <$> strVal)
+
 
 -- | Parse the next-phoneme string, checking
 --   that it matches one of the given groups,

--- a/src/Metamorth/Interpretation/Parser/Parsing.hs
+++ b/src/Metamorth/Interpretation/Parser/Parsing.hs
@@ -692,7 +692,8 @@ parseNextCheckB  = do
 
 -- | Parse the next-phoneme string, checking
 --   that it matches one of the given groups,
---   traits, aspects, or phonemes.
+--   traits, aspects, or phonemes. Old version
+--   only around for compatibility.
 parseNextCheckS :: ParserParser (Maybe FollowPattern)
 parseNextCheckS = do
   mval <- parseNextCheckSB
@@ -706,6 +707,9 @@ parseNextCheckSB2 = do
   -- sequenceA :: (Traversable t) => t (Maybe a) -> Maybe (t a)
   return $ sequenceA b2
 
+-- | Parse the next-phoneme string, checking
+--   that it matches one of the given groups,
+--   traits, aspects, or phonemes.
 parseNextCheckSB :: ParserParser (Boolean2 (Maybe FollowPattern))
 parseNextCheckSB = do
   -- (prop, mval) <- lift parseNextCheck

--- a/src/Metamorth/Interpretation/Parser/Parsing/Boolean.hs
+++ b/src/Metamorth/Interpretation/Parser/Parsing/Boolean.hs
@@ -19,6 +19,7 @@ module Metamorth.Interpretation.Parser.Parsing.Boolean
   , evaluate2
   , leftmostB2
   , showBoolTree2
+  , showBoolTree2'
   -- * Arbitrary length And/Or
   , BooleanA(..)
   , evaluateA
@@ -99,6 +100,13 @@ showBoolTree2 (PlainB2 x) = show x
 showBoolTree2 (NotB2   x) = '~' : (showBoolTree2 x)
 showBoolTree2 (AndB2 x y) = '(' : (showBoolTree2 x) ++ '&' : (showBoolTree2 y) ++ ")"
 showBoolTree2 (OrB2  x y) = '(' : (showBoolTree2 x) ++ '|' : (showBoolTree2 y) ++ ")"
+
+showBoolTree2' :: (a -> String) -> Boolean2 a -> String
+showBoolTree2' f (PlainB2 x) = f x
+showBoolTree2' f (NotB2   x) = '~' : (showBoolTree2' f x)
+showBoolTree2' f (AndB2 x y) = '(' : (showBoolTree2' f x) ++ '&' : (showBoolTree2' f y) ++ ")"
+showBoolTree2' f (OrB2  x y) = '(' : (showBoolTree2' f x) ++ '|' : (showBoolTree2' f y) ++ ")"
+
 
 -- | A boolean expression tree tree that
 --   arbitrarily many sub-expressions for

--- a/src/Metamorth/Interpretation/Parser/Parsing/Boolean.hs
+++ b/src/Metamorth/Interpretation/Parser/Parsing/Boolean.hs
@@ -17,6 +17,7 @@ module Metamorth.Interpretation.Parser.Parsing.Boolean
   -- * Binary And/Or Only
   ( Boolean2(..)
   , evaluate2
+  , leftmostB2
   -- * Arbitrary length And/Or
   , BooleanA(..)
   , evaluateA
@@ -35,7 +36,7 @@ data Boolean2 a
   | NotB2 (Boolean2 a)
   | AndB2 (Boolean2 a) (Boolean2 a)
   | OrB2  (Boolean2 a) (Boolean2 a)
-  deriving (Show, Eq)
+  deriving (Show, Eq, Ord)
 
 instance Functor Boolean2 where
   fmap f (PlainB2 a) = PlainB2 (f a)
@@ -84,6 +85,14 @@ evaluate2 f (NotB2   x) = not (evaluate2 f x)
 evaluate2 f (AndB2 x y) = (evaluate2 f x) && (evaluate2 f y)
 evaluate2 f (OrB2  x y) = (evaluate2 f x) || (evaluate2 f y)
 
+-- | Extract the "leftmost" element from
+--   a `Boolean2` tree.
+leftmostB2 :: Boolean2 a -> a
+leftmostB2 (PlainB2 x) = x
+leftmostB2 (NotB2   x) = leftmostB2 x
+leftmostB2 (AndB2 x _) = leftmostB2 x
+leftmostB2 (OrB2  x _) = leftmostB2 x
+
 -- | A boolean expression tree tree that
 --   arbitrarily many sub-expressions for
 --   "AND" and "OR".
@@ -92,7 +101,7 @@ data BooleanA a
   | NotBA (BooleanA a)
   | AndBA (NonEmpty (BooleanA a))
   | OrBA  (NonEmpty (BooleanA a))
-  deriving (Show, Eq)
+  deriving (Show, Eq, Ord)
 
 instance Functor BooleanA where
   fmap f (PlainBA a) = PlainBA (f a)

--- a/src/Metamorth/Interpretation/Parser/Parsing/Boolean.hs
+++ b/src/Metamorth/Interpretation/Parser/Parsing/Boolean.hs
@@ -18,6 +18,7 @@ module Metamorth.Interpretation.Parser.Parsing.Boolean
   ( Boolean2(..)
   , evaluate2
   , leftmostB2
+  , showBoolTree2
   -- * Arbitrary length And/Or
   , BooleanA(..)
   , evaluateA
@@ -92,6 +93,12 @@ leftmostB2 (PlainB2 x) = x
 leftmostB2 (NotB2   x) = leftmostB2 x
 leftmostB2 (AndB2 x _) = leftmostB2 x
 leftmostB2 (OrB2  x _) = leftmostB2 x
+
+showBoolTree2 :: (Show a) => Boolean2 a -> String
+showBoolTree2 (PlainB2 x) = show x
+showBoolTree2 (NotB2   x) = '~' : (showBoolTree2 x)
+showBoolTree2 (AndB2 x y) = '(' : (showBoolTree2 x) ++ '&' : (showBoolTree2 y) ++ ")"
+showBoolTree2 (OrB2  x y) = '(' : (showBoolTree2 x) ++ '|' : (showBoolTree2 y) ++ ")"
 
 -- | A boolean expression tree tree that
 --   arbitrarily many sub-expressions for

--- a/src/Metamorth/Interpretation/Parser/Parsing/Boolean.hs
+++ b/src/Metamorth/Interpretation/Parser/Parsing/Boolean.hs
@@ -1,0 +1,144 @@
+{-|
+Module      : Metamorth.Interpretation.Parser.Parsing.Boolean
+Description : Boolean Trees
+Copyright   : (c) David Wilson, 2024
+License     : BSD-3
+
+This is a module where I create a type that
+represents a boolean expression. The reason
+to do it expressly here is so that it can
+be made an instance of `Traversable`, so
+we can easily lift existing code over a full
+expression.
+
+-}
+
+module Metamorth.Interpretation.Parser.Parsing.Boolean
+  -- * Binary And/Or Only
+  ( Boolean2(..)
+  , evaluate2
+  -- * Arbitrary length And/Or
+  , BooleanA(..)
+  , evaluateA
+  ) where
+
+import Data.List.NonEmpty qualified as NE
+import Data.List.NonEmpty (NonEmpty(..))
+
+import Data.Semigroup
+
+-- | A boolean expression tree tree that
+--   only allows two sub-expressions for 
+--   "AND" and "OR".
+data Boolean2 a
+  = PlainB2 a
+  | NotB2 (Boolean2 a)
+  | AndB2 (Boolean2 a) (Boolean2 a)
+  | OrB2  (Boolean2 a) (Boolean2 a)
+  deriving (Show, Eq)
+
+instance Functor Boolean2 where
+  fmap f (PlainB2 a) = PlainB2 (f a)
+  fmap f (NotB2 x)   = NotB2 (fmap f x)
+  fmap f (AndB2 x y) = AndB2 (fmap f x) (fmap f y)
+  fmap f (OrB2  x y) = OrB2  (fmap f x) (fmap f y)
+
+instance Foldable Boolean2 where
+  foldMap f (PlainB2 x) = f x
+  foldMap f (NotB2   x) = foldMap f x
+  foldMap f (AndB2 x y) = (foldMap f x) <> (foldMap f y)
+  foldMap f (OrB2  x y) = (foldMap f x) <> (foldMap f y)
+
+  -- foldr :: (a -> b -> b) -> b -> [a] -> b
+  foldr ap acc (PlainB2 x) = ap x acc
+  foldr ap acc (NotB2   x) = foldr ap acc x 
+  foldr ap acc (AndB2 x y) = foldr ap (foldr ap acc y) x 
+  foldr ap acc (OrB2  x y) = foldr ap (foldr ap acc y) x 
+
+  -- foldl :: (b -> a -> b) -> b -> [a] -> b
+  foldl ap acc (PlainB2 x) = ap acc x
+  foldl ap acc (NotB2   x) = foldl ap acc x
+  foldl ap acc (AndB2 x y) = foldl ap (foldl ap acc x) y
+  foldl ap acc (OrB2  x y) = foldl ap (foldl ap acc x) y
+
+-- Now, the hard one...
+instance Traversable Boolean2 where
+  -- sequenceA :: Applicative f => t (f a) -> f (t a)
+  sequenceA (PlainB2    act1) = PlainB2 <$> act1
+  sequenceA (NotB2      act1) = NotB2   <$> sequenceA act1
+  sequenceA (AndB2 act1 act2) = AndB2   <$> sequenceA act1 <*> sequenceA act2
+  sequenceA (OrB2  act1 act2) = OrB2    <$> sequenceA act1 <*> sequenceA act2
+
+  -- traverse :: Applicative f (a -> f b) -> t a -> f (t b)
+  traverse f (PlainB2 x) = PlainB2 <$> f x
+  traverse f (NotB2   x) = NotB2   <$> traverse f x
+  traverse f (AndB2 x y) = AndB2   <$> traverse f x <*> traverse f y
+  traverse f (OrB2  x y) = OrB2    <$> traverse f x <*> traverse f y
+
+-- | Evaluate a `Boolean2` structure by
+--   applying a predicate to every entry
+--   in the tree.
+evaluate2 :: (a -> Bool) -> Boolean2 a -> Bool
+evaluate2 f (PlainB2 x) = f x
+evaluate2 f (NotB2   x) = not (evaluate2 f x)
+evaluate2 f (AndB2 x y) = (evaluate2 f x) && (evaluate2 f y)
+evaluate2 f (OrB2  x y) = (evaluate2 f x) || (evaluate2 f y)
+
+-- | A boolean expression tree tree that
+--   arbitrarily many sub-expressions for
+--   "AND" and "OR".
+data BooleanA a
+  = PlainBA a
+  | NotBA (BooleanA a)
+  | AndBA (NonEmpty (BooleanA a))
+  | OrBA  (NonEmpty (BooleanA a))
+  deriving (Show, Eq)
+
+instance Functor BooleanA where
+  fmap f (PlainBA a) = PlainBA (f a)
+  fmap f (NotBA   x) = NotBA   (fmap f x)
+  fmap f (AndBA  xs) = AndBA   (fmap (fmap f) xs)
+  fmap f (OrBA   xs) = OrBA    (fmap (fmap f) xs)
+
+instance Foldable BooleanA where
+  foldMap f (PlainBA x) = f x
+  foldMap f (NotBA   x) = foldMap f x
+  foldMap f (AndBA  xs) = sconcat (fmap (foldMap f) xs)
+  foldMap f (OrBA   xs) = sconcat (fmap (foldMap f) xs)
+
+  -- foldr :: (a -> b -> b) -> b -> [a] -> b
+  foldr ap acc (PlainBA x) = ap x acc
+  foldr ap acc (NotBA   x) = foldr ap acc x 
+  foldr ap acc (AndBA  xs) = foldr (\x y -> foldr ap y x) acc xs
+  foldr ap acc (OrBA   xs) = foldr (\x y -> foldr ap y x) acc xs
+
+  -- foldl :: (b -> a -> b) -> b -> [a] -> b
+  foldl ap acc (PlainBA x) = ap acc x
+  foldl ap acc (NotBA   x) = foldl ap acc x
+  foldl ap acc (AndBA  xs) = foldl (foldl ap) acc xs
+  foldl ap acc (OrBA   xs) = foldl (foldl ap) acc xs
+
+-- Now, the hard one...
+instance Traversable BooleanA where
+  -- sequenceA :: Applicative f => t (f a) -> f (t a)
+  sequenceA (PlainBA action) = PlainBA <$> action
+  sequenceA (NotBA   action) = NotBA   <$> sequenceA action
+  sequenceA (AndBA  actions) = AndBA   <$> traverse sequenceA actions
+  sequenceA (OrBA   actions) = OrBA    <$> traverse sequenceA actions
+
+  -- traverse :: Applicative f (a -> f b) -> t a -> f (t b)
+  traverse f (PlainBA x) = PlainBA <$> f x
+  traverse f (NotBA   x) = NotBA   <$> traverse f x
+  traverse f (AndBA  xs) = AndBA   <$> traverse (traverse f) xs
+  traverse f (OrBA   xs) = OrBA    <$> traverse (traverse f) xs
+  -- xs :: (NonEmpty (BooleanA a))
+
+-- | Evaluate a `BooleanA` structure by
+--   applying a predicate to every entry
+--   in the tree.
+evaluateA :: (a -> Bool) -> BooleanA a -> Bool
+evaluateA f (PlainBA x) = f x
+evaluateA f (NotBA   x) = not (evaluateA f x)
+evaluateA f (AndBA  xs) = all (evaluateA f) xs
+evaluateA f (OrBA   xs) = any (evaluateA f) xs
+

--- a/src/Metamorth/Interpretation/Parser/Parsing/Expr.hs
+++ b/src/Metamorth/Interpretation/Parser/Parsing/Expr.hs
@@ -50,7 +50,7 @@ parseAnd = do
     (Just '&') -> void AT.anyChar
     _ -> return ()
   skipHoriz
-  return OrB2
+  return AndB2
 
 parseNot :: AT.Parser (Boolean2 a -> Boolean2 a)
 parseNot = do
@@ -66,8 +66,8 @@ parseBoolean :: AT.Parser a -> AT.Parser (Boolean2 a)
 parseBoolean termParser = makeExprParser
   (parseParens termParser)
   [ [ Prefix parseNot ]
-  , [ InfixR parseOr  ]
   , [ InfixR parseAnd ]
+  , [ InfixR parseOr  ]
   ]
 
 -- | One of the main ways to call the parser for

--- a/src/Metamorth/Interpretation/Parser/Parsing/Expr.hs
+++ b/src/Metamorth/Interpretation/Parser/Parsing/Expr.hs
@@ -35,8 +35,8 @@ parseOr = do
   c <- AT.peekChar
   -- Allow for double bars...
   case c of
-    (Just '|') -> void AT.anyChar
-    _ -> return ()
+    (Just '|') -> void AT.anyChar -- consume the char
+    _          -> return () -- don't consume the char
   skipHoriz
   return OrB2
 
@@ -47,8 +47,8 @@ parseAnd = do
   c <- AT.peekChar
   -- Allow for double ampersands...
   case c of
-    (Just '&') -> void AT.anyChar
-    _ -> return ()
+    (Just '&') -> void AT.anyChar -- consume the char
+    _          -> return () -- don't consume the char
   skipHoriz
   return AndB2
 

--- a/src/Metamorth/Interpretation/Parser/Parsing/Expr.hs
+++ b/src/Metamorth/Interpretation/Parser/Parsing/Expr.hs
@@ -1,0 +1,133 @@
+{-|
+Module      : Metamorth.Interpretation.Parser.Parsing.Expr
+Description : Boolean Tree Parsing
+Copyright   : (c) David Wilson, 2024
+License     : BSD-3
+
+This module is for parsing expressions into
+the boolean trees seen in "Metamorth.Interpretation.Parser.Parsing.Expr".
+
+-}
+
+module Metamorth.Interpretation.Parser.Parsing.Expr
+  ( parseBoolean
+  , parseParens
+  , parseBooleanExpr
+  , parseBooleanExpr'
+  ) where
+
+import Metamorth.Interpretation.Parser.Parsing.Boolean
+
+import Data.Attoparsec.Text       qualified as AT
+import Data.Attoparsec.Combinator qualified as AC
+
+import Control.Monad
+
+import Control.Monad.Combinators
+import Control.Monad.Combinators.Expr
+
+import Metamorth.Helpers.Parsing
+
+parseOr :: AT.Parser (Boolean2 a -> Boolean2 a -> Boolean2 a)
+parseOr = do
+  skipHoriz
+  AT.char '|'
+  c <- AT.peekChar
+  -- Allow for double bars...
+  case c of
+    (Just '|') -> void AT.anyChar
+    _ -> return ()
+  skipHoriz
+  return OrB2
+
+parseAnd :: AT.Parser (Boolean2 a -> Boolean2 a -> Boolean2 a)
+parseAnd = do
+  skipHoriz
+  _ <- AT.char '&'
+  c <- AT.peekChar
+  -- Allow for double ampersands...
+  case c of
+    (Just '&') -> void AT.anyChar
+    _ -> return ()
+  skipHoriz
+  return OrB2
+
+parseNot :: AT.Parser (Boolean2 a -> Boolean2 a)
+parseNot = do
+  skipHoriz
+  _ <- AT.satisfy (\x -> x == '!' || x == '~')
+  return NotB2
+
+-- | One of the main ways to call the
+--   parser for the Boolean Tree. This
+--   one does not require parentheses around
+--   expressions.
+parseBoolean :: AT.Parser a -> AT.Parser (Boolean2 a)
+parseBoolean termParser = makeExprParser
+  (parseParens termParser)
+  [ [ Prefix parseNot ]
+  , [ InfixR parseOr  ]
+  , [ InfixR parseAnd ]
+  ]
+
+-- | One of the main ways to call the parser for
+--   the boolean tree. This one **does** require
+--   parentheses around expressions, but not around
+--   individual terms. It still requires them around
+--   single @not@ expressions.
+parseParens :: AT.Parser a -> AT.Parser (Boolean2 a)
+parseParens termParser = (between (AT.char '(') (AT.char ')') (parseBoolean termParser))
+   <|> (PlainB2 <$> termParser)
+
+parseNotOnly :: AT.Parser a -> AT.Parser (Boolean2 a)
+parseNotOnly termParser = do
+  _ <- AT.satisfy (\x -> x == '!' || x == '~')
+  NotB2 <$> parseParens termParser
+
+-- | One of the main ways to call the parser for
+--   the boolean tree. This one **does** require
+--   parentheses around expressions, but not around
+--   individual terms. Unlike `parseParens`, it also
+--   does not require them around individual @not@
+--   expressions. 
+--
+--   Also note that when encountering an expression 
+--   such as
+--
+--     @ !2|5 @
+--
+--   this function will *not* fail, and instead leave 
+--   the parser position between the @2@ and the @|@. 
+--   This can be a problem, since the program won't
+--   realise that it's midway through an expression.
+parseBooleanExpr' :: AT.Parser a -> AT.Parser (Boolean2 a)
+parseBooleanExpr' termParser
+  = parseParens termParser <|> parseNotOnly termParser
+
+-- | One of the main ways to call the parser for
+--   the boolean tree. This one **does** require
+--   parentheses around expressions, but not around
+--   individual terms. Unlike `parseParens`, it also
+--   does not require them around individual @not@
+--   expressions. 
+--
+--   This function also (hopefully) avoids the pitfalls
+--   of `parseBooleanExpr'` by looking ahead to see
+--   whether the incoming input looks like an expression.
+parseBooleanExpr :: AT.Parser a -> AT.Parser (Boolean2 a)
+parseBooleanExpr termParser = do
+  expr <- parseBooleanExpr' termParser
+  rslt <- AC.lookAhead $ do
+    skipHoriz
+    c <- AT.peekChar
+    -- Note: Maybe return more of the following result
+    -- to make troubleshooting easier.
+    case c of
+      (Just '|') -> return True
+      (Just '&') -> return True
+      _ -> return False
+  
+  when rslt $ fail "Expression not enclosed in parentheses."
+
+  return expr
+

--- a/src/Metamorth/Interpretation/Parser/TH.hs
+++ b/src/Metamorth/Interpretation/Parser/TH.hs
@@ -1394,7 +1394,7 @@ data PhoneResult = PhoneResult
     finalRslt = case restPats of
       (Just lookAheadTrie) -> otherwiseG <$> do
         -- newMap :: M.Map [ModifyStateX] [(FollowPattern, (NonEmpty PhoneName, Caseness))]
-        let newMap = groupMods $ unmapLookaheadTrie lookAheadTrie
+        let newMap = groupModsB $ unmapLookaheadTrie lookAheadTrie
         case (M.size newMap) of
           0 -> case mTrieVal of
             Nothing -> return $ AppE (VarE 'fail) (LitE (StringL $ "Couldn't find a match for pattern: \"" ++ (ppCharPats precPatrn) ++ "\"."))
@@ -1407,7 +1407,7 @@ data PhoneResult = PhoneResult
             stModLamb <- makeModifyStatesLA sdict pmod 
 
             folPatsP <- forM followPairs $ \(fPat, (phoneNoms, csn)) -> do
-                  let consPats = constructFollowPats newPhoneMap groupFuncs aspectFuncs traitFuncs' fPat
+                  let consPats = constructFollowPatsB newPhoneMap groupFuncs aspectFuncs traitFuncs' fPat
                   cstrExp <- phoneNamePatterns patMap aspMaps phoneNoms
                   -- resultModifier <- modifyStateExps sdict pmod
                   return (consPats, phonemeRet' mkMaj mkMin csn mbl cstrExp)
@@ -1437,7 +1437,7 @@ data PhoneResult = PhoneResult
               rslts <- forM followPairs $ \(folPat, (phoneRslt, csn)) -> do
                 -- Basically the same as above.
                 -- consPats :: Exp -> Exp
-                let consPats = constructFollowPats newPhoneMap groupFuncs aspectFuncs traitFuncs' folPat
+                let consPats = constructFollowPatsB newPhoneMap groupFuncs aspectFuncs traitFuncs' folPat
                 -- Might need to ensure that the state is properly modified in
                 -- the result.
                 cstrExp <- phoneNamePatterns patMap aspMaps phoneRslt
@@ -1533,7 +1533,7 @@ makeGuards Nothing charVarName trieAnn mTrieVal theTrie funcMap mkMaj mkMin patM
     finalRslt = case restPats of
       (Just lookAheadTrie) -> otherwiseG <$> do
         -- newMap :: M.Map [ModifyStateX] [(FollowPattern, (NonEmpty PhoneName, Caseness))]
-        let newMap = groupMods $ unmapLookaheadTrie lookAheadTrie
+        let newMap = groupModsB $ unmapLookaheadTrie lookAheadTrie
         case (M.size newMap) of
           0 -> case mTrieVal of
             Nothing -> return $ AppE (VarE 'fail) (LitE (StringL $ "Couldn't find a match for pattern: \"" ++ (ppCharPats precPatrn) ++ "\"."))
@@ -1546,7 +1546,7 @@ makeGuards Nothing charVarName trieAnn mTrieVal theTrie funcMap mkMaj mkMin patM
             stModLamb <- makeModifyStatesLA sdict pmod 
 
             folPatsP <- forM followPairs $ \(fPat, (phoneNoms, csn)) -> do
-                  let consPats = constructFollowPats newPhoneMap groupFuncs aspectFuncs traitFuncs' fPat
+                  let consPats = constructFollowPatsB newPhoneMap groupFuncs aspectFuncs traitFuncs' fPat
                   cstrExp <- phoneNamePatterns patMap aspMaps phoneNoms
                   -- resultModifier <- modifyStateExps sdict pmod
                   return (consPats, phonemeRet' mkMaj mkMin csn Nothing cstrExp)
@@ -1576,7 +1576,7 @@ makeGuards Nothing charVarName trieAnn mTrieVal theTrie funcMap mkMaj mkMin patM
               rslts <- forM followPairs $ \(folPat, (phoneRslt, csn)) -> do
                 -- Basically the same as above.
                 -- consPats :: Exp -> Exp
-                let consPats = constructFollowPats newPhoneMap groupFuncs aspectFuncs traitFuncs' folPat
+                let consPats = constructFollowPatsB newPhoneMap groupFuncs aspectFuncs traitFuncs' folPat
                 -- Might need to ensure that the state is properly modified in
                 -- the result.
                 cstrExp <- phoneNamePatterns patMap aspMaps phoneRslt

--- a/src/Metamorth/Interpretation/Parser/Types.hs
+++ b/src/Metamorth/Interpretation/Parser/Types.hs
@@ -24,6 +24,7 @@ module Metamorth.Interpretation.Parser.Types
   , FollowPattern(..)
   , isFollowPat
   , getFollowPat
+  , getFollowPatB
   ) where
 
 import Data.Bifunctor
@@ -47,6 +48,8 @@ import Data.Set qualified as S
 import Metamorth.Helpers.Either
 import Metamorth.Helpers.Ord
 
+import Metamorth.Interpretation.Parser.Parsing.Boolean
+
 -- | The data that's found in the header of the
 --   parser file.
 data HeaderData = HeaderData
@@ -69,7 +72,7 @@ data CharPatternRaw
   | NotEndR           -- ^ NOT the end of a word.
   | ValStateR String (Either String Bool) -- ^ Check that the state is a certain value.
   | SetStateR String (Either String Bool) -- ^ Set the state to a certain value.
-  | FollowPatR FollowPattern
+  | FollowPatR (Boolean2 FollowPattern)
   deriving (Show, Eq, Ord)
 
 data FollowPattern
@@ -110,7 +113,7 @@ data CharPatternF b
   | WordEnd                 -- ^ The end of a word.
   | NotStart                -- ^ NOT the start of a word.
   | NotEnd                  -- ^ NOT the end of a word.
-  | FollowPat FollowPattern -- ^ A `FollowPattern`
+  | FollowPat (Boolean2 FollowPattern) -- ^ A boolean expression of `FollowPattern`s.
   deriving (Show, Eq)
 
 isFollowPat :: CharPattern -> Bool
@@ -118,8 +121,12 @@ isFollowPat (FollowPat _) = True
 isFollowPat _ = False
 
 getFollowPat :: CharPattern -> Maybe FollowPattern
-getFollowPat (FollowPat x) = Just x
+getFollowPat (FollowPat x) = Just $ leftmostB2 x
 getFollowPat _ = Nothing
+
+getFollowPatB :: CharPattern -> Maybe (Boolean2 FollowPattern)
+getFollowPatB (FollowPat x) = Just x
+getFollowPatB _ = Nothing
 
 -- Make (CharPatternF (Down b)) an instance of `Ord` so that
 -- (CharPatternF b) has something to derive via. Also make this

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -168,6 +168,12 @@ main = do
     (Left err) -> putStrLn $ "Error: " ++ err
     (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
 
+  putStrLn "Testing output lookahead..."
+  let look4 = TLE.decodeUtf8 <$> Fol.convertOrthographyBS Fol.InFollowA Fol.OutLookahead lookAheadTest4
+  case look4 of
+    (Left err) -> putStrLn $ "Error: " ++ err
+    (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
+
 
 
 -- | From the Inuktitut Wikipedia page for Inuktitut.
@@ -208,6 +214,9 @@ lookAheadTest2 = "þaβ þбa þnaḅ"
 
 lookAheadTest3 :: T.Text
 lookAheadTest3 = "ɵin ɵyn ɵyd ɵyg"
+
+lookAheadTest4 :: T.Text
+lookAheadTest4 = "apabaranadax awshawchawg"
 
 {-
    b : example=exam1

--- a/test/Test/TH/Following.hs
+++ b/test/Test/TH/Following.hs
@@ -20,9 +20,10 @@ declareFullParsers
   [ ("examples/parsing/example_follow_01.thyp", (defExtraParserDetails "_f01") {epdParserName = "follow1Parser", epdOtherNames = ["f1"]} )
   , ("examples/parsing/lookahead_example.thyp", (defExtraParserDetails "_lah") {epdParserName = "followLParser", epdOtherNames = ["la"]} )
   ]
-  [ ("examples/output/example_follow_01.thyo", defExtraOutputDetails {eodSuffix = "_f01out", eodOutputName = "follow1Output", eodOtherNames = ["f1"]}) 
-  , ("examples/output/example_follow_02.thyo", defExtraOutputDetails {eodSuffix = "_f02out", eodOutputName = "follow2Output", eodOtherNames = ["f2"]}) 
-  , ("examples/output/example_follow_03.thyo", defExtraOutputDetails {eodSuffix = "_f03out", eodOutputName = "follow3Output", eodOtherNames = ["f3"]}) 
+  [ ("examples/output/example_follow_01.thyo"   , defExtraOutputDetails {eodSuffix = "_f01out", eodOutputName = "follow1Output", eodOtherNames = ["f1"]}) 
+  , ("examples/output/example_follow_02.thyo"   , defExtraOutputDetails {eodSuffix = "_f02out", eodOutputName = "follow2Output", eodOtherNames = ["f2"]}) 
+  , ("examples/output/example_follow_03.thyo"   , defExtraOutputDetails {eodSuffix = "_f03out", eodOutputName = "follow3Output", eodOtherNames = ["f3"]}) 
+  , ("examples/output/lookahead_example_01.thyo", defExtraOutputDetails {eodSuffix = "_f04out", eodOutputName = "follow4Output", eodOtherNames = ["f4"]}) 
   ]
 
 

--- a/test/Test/TH/Following.hs
+++ b/test/Test/TH/Following.hs
@@ -25,3 +25,4 @@ declareFullParsers
   , ("examples/output/example_follow_03.thyo", defExtraOutputDetails {eodSuffix = "_f03out", eodOutputName = "follow3Output", eodOtherNames = ["f3"]}) 
   ]
 
+


### PR DESCRIPTION
This PR adds the ability to use Boolean expressions when using lookahead when writing a parser. This is one of the additional features mentioned in #7 that I didn't implement in the last PR (#18). As it turns out, implementing Boolean expressions for lookahead was _much_ easier than I had anticipated. 

On the other hand, the other major feature mentioned in #7, looking ahead more than one phoneme, would be much more difficult to integrate into the current code for lookahead. I may still try to implement it, but it would almost certainly take longer than implementing Boolean expressions.