### PR TITLE
Add support to allow dictionary generation

### DIFF
--- a/examples/output/kwakwala_mfa.thyo
+++ b/examples/output/kwakwala_mfa.thyo
@@ -1,0 +1,79 @@
+name : MFA
+
+default case : /
+
+====
+
+# no states or classes
+
+add_spaces
+
+====
+
+m  : M
+m' : M _ G
+n  : N
+n' : N _ G
+
+l  : L
+l' : L _ G
+lh : L H
+
+j  : Y
+j' : Y _ G
+
+w  : W
+w' : W _ G
+
+p  : P
+p' : P_E
+b  : B
+
+t   : T
+ts  : T S
+ts' : T S _ E
+tl  : T L
+tl' : T L _ E
+
+d   : D
+dl  : D L
+dz  : D Z
+s   : S
+
+k   : K
+k'  : K _ E
+kw  : K W
+kw' : K W _ E
+
+q   : Q
+q'  : Q _ E
+qw  : Q W
+qw' : Q W _ E
+
+g   : G
+gw  : G W
+gh  : G U
+ghw : G U W
+
+x   : X
+xw  : X W
+xh  : X H
+xhw : X H W
+
+h   : H
+glt : GLT
+
+a     : A
+e     : E
+i     : I
+o     : O
+u     : U
+schwa : Ə
+
+# ^ glt a     : a
+# ^ glt e     : e h
+# ^ glt i     : i
+# ^ glt o     : o
+# ^ glt u     : u
+# ^ glt schwa : e
+

--- a/examples/output/kwakwala_mfa.thyo
+++ b/examples/output/kwakwala_mfa.thyo
@@ -26,7 +26,7 @@ w  : W
 w' : W _ G
 
 p  : P
-p' : P_E
+p' : P _ E
 b  : B
 
 t   : T
@@ -61,7 +61,7 @@ xh  : X H
 xhw : X H W
 
 h   : H
-glt : GLT
+glt : G L T
 
 a     : A
 e     : E

--- a/metamorTHysis.cabal
+++ b/metamorTHysis.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -54,6 +54,7 @@ library
       Metamorth.Helpers.Q
       Metamorth.Helpers.QP
       Metamorth.Helpers.QS
+      Metamorth.Helpers.State
       Metamorth.Helpers.String
       Metamorth.Helpers.TH
       Metamorth.Helpers.Trie

--- a/metamorTHysis.cabal
+++ b/metamorTHysis.cabal
@@ -54,6 +54,7 @@ library
       Metamorth.Helpers.Q
       Metamorth.Helpers.QP
       Metamorth.Helpers.QS
+      Metamorth.Helpers.RWS
       Metamorth.Helpers.State
       Metamorth.Helpers.String
       Metamorth.Helpers.TH

--- a/src/Metamorth/ForOutput/Monad/Matcher.hs
+++ b/src/Metamorth/ForOutput/Monad/Matcher.hs
@@ -363,7 +363,7 @@ matchesR err f = do
       y <- match err f
       (y <>) <$> matchesR err f
 
--- | Like `matchesL`, but uses a different function
+-- | Like `matchesR`, but uses a different function
 --   for the first match.
 matchesR' :: (MonadPlus m, Monoid v, Monoid r) => (String -> m r) -> (i -> MatchResult m i v r) -> (i -> MatchResult m i v r) -> MatcherT i v m r
 matchesR' err f1 f2 = do
@@ -374,7 +374,7 @@ matchesR' err f1 f2 = do
       y <- match err f1
       (y <>) <$> matchesR err f2
 
--- | Like `matchesL`, but uses `fail` for
+-- | Like `matchesR`, but uses `fail` for
 --   the first argument.
 matchesRF :: (MonadPlus m, MonadFail m, Monoid v, Monoid r) => (i -> MatchResult m i v r) -> MatcherT i v m r
 matchesRF = matchesR fail

--- a/src/Metamorth/ForOutput/Monad/Matcher/Stateful/Extra.hs
+++ b/src/Metamorth/ForOutput/Monad/Matcher/Stateful/Extra.hs
@@ -18,7 +18,7 @@ In the future, these modules may be moved
 to a separate package.
 
 This module is an add-on to "Metamorth.ForOutput.Monad.Matcher.Stateful"
-that allows pre-processing of 
+that allows pre-processing of the input stream.
 
 -}
 
@@ -237,7 +237,7 @@ matchesRX prp err f = do
       y <- matchX prp err f
       (y <>) <$> matchesRX prp err f
 
--- | Like `matchesL`, but uses a different function
+-- | Like `matchesRX`, but uses a different function
 --   for the first match.
 matchesRX' :: (MonadPlus m, Monoid v, Monoid r) => (i -> j) -> (String -> m r) -> (j -> MatchResult m j v s r) -> (j -> MatchResult m j v s r) -> MatcherT i v s m r
 matchesRX' prp err f1 f2 = do
@@ -248,7 +248,7 @@ matchesRX' prp err f1 f2 = do
       y <- matchX prp err f1
       (y <>) <$> matchesRX prp err f2
 
--- | Like `matchesL`, but uses `fail` for
+-- | Like `matchesRX`, but uses `fail` for
 --   the first argument.
 matchesRFX :: (MonadPlus m, MonadFail m, Monoid v, Monoid r) => (i -> j) -> (j -> MatchResult m j v s r) -> MatcherT i v s m r
 matchesRFX prp = matchesRX prp fail

--- a/src/Metamorth/Helpers/RWS.hs
+++ b/src/Metamorth/Helpers/RWS.hs
@@ -1,0 +1,51 @@
+module Metamorth.Helpers.RWS
+  -- * Re-Ordered Runners
+  -- ** Non-Monadic
+  ( rwsRun
+  , rwsEval
+  , rwsExec
+  -- ** Monadic
+  , rwsRunT
+  , rwsEvalT
+  , rwsExecT
+  -- * Extra Functions
+  , modify'
+  ) where
+
+import Control.Monad.Trans.RWS.CPS qualified as RWS
+
+-- | Like `RWS.runRWS`, but opposite argument order.
+rwsRun :: Monoid w => r -> s -> RWS.RWS r w s a -> (a, s, w)
+rwsRun rdr st op = RWS.runRWS op rdr st
+{-# INLINE rwsRun #-}
+
+-- | Like `RWS.evalRWS`, but opposite argument order.
+rwsEval :: Monoid w => r -> s -> RWS.RWS r w s a -> (a,w)
+rwsEval rdr st op = RWS.evalRWS op rdr st
+{-# INLINE rwsEval #-}
+
+-- | Like `RWS.execState`, but opposite argument order.
+rwsExec :: Monoid w => r -> s -> RWS.RWS r w s a -> (s, w)
+rwsExec rdr st op = RWS.execRWS op rdr st
+{-# INLINE rwsExec #-}
+
+-- | Like `RWS.runRWST`, but opposite argument order.
+rwsRunT :: Monoid w => r -> s -> RWS.RWST r w s m a -> m (a, s, w)
+rwsRunT rdr st op = RWS.runRWST op rdr st
+{-# INLINE rwsRunT #-}
+
+-- | Like `RWS.evalRWST`, but opposite argument order.
+rwsEvalT :: (Monad m, Monoid w) => r -> s -> RWS.RWST r w s m a -> m (a,w)
+rwsEvalT rdr st op = RWS.evalRWST op rdr st
+{-# INLINE rwsEvalT #-}
+
+-- | Like `RWS.execRWST`, but opposite argument order.
+rwsExecT :: (Monad m, Monoid w) => r -> s -> RWS.RWST r w s m a -> m (s, w)
+rwsExecT rdr st op = RWS.execRWST op rdr st
+{-# INLINE rwsExecT #-}
+
+-- | Strict variant of `RWS.modify`.
+modify' :: (Monad m) => (s -> s) -> RWS.RWST r w s m ()
+modify' f = do
+  s <- RWS.get
+  RWS.put $! f s

--- a/src/Metamorth/Helpers/State.hs
+++ b/src/Metamorth/Helpers/State.hs
@@ -1,0 +1,41 @@
+module Metamorth.Helpers.State
+  ( stateRun
+  , stateEval
+  , stateExec
+  , stateRunT
+  , stateEvalT
+  , stateExecT
+  ) where
+
+import Control.Monad.Trans.State.Strict qualified as State
+
+-- | Like `State.runState`, but opposite argument order.
+stateRun :: s -> State.State s a -> (a, s)
+stateRun st op = State.runState op st
+{-# INLINE stateRun #-}
+
+-- | Like `State.evalState`, but opposite argument order.
+stateEval :: s -> State.State s a -> a
+stateEval st op = State.evalState op st
+{-# INLINE stateEval #-}
+
+-- | Like `State.execState`, but opposite argument order.
+stateExec :: s -> State.State s a -> s
+stateExec st op = State.execState op st
+{-# INLINE stateExec #-}
+
+
+-- | Like `State.runState`, but opposite argument order.
+stateRunT :: Monad m => s -> State.StateT s m a -> m (a, s)
+stateRunT st op = State.runStateT op st
+{-# INLINE stateRunT #-}
+
+-- | Like `State.evalState`, but opposite argument order.
+stateEvalT :: Monad m => s -> State.StateT s m a -> m a
+stateEvalT st op = State.evalStateT op st
+{-# INLINE stateEvalT #-}
+
+-- | Like `State.execState`, but opposite argument order.
+stateExecT :: Monad m => s -> State.StateT s m a -> m s
+stateExecT st op = State.execStateT op st
+{-# INLINE stateExecT #-}

--- a/src/Metamorth/Interaction/Quasi.hs
+++ b/src/Metamorth/Interaction/Quasi.hs
@@ -13,6 +13,7 @@ import Data.Map.Strict qualified as M
 import Metamorth.Helpers.Error
 import Metamorth.Helpers.TH (forMap)
 import Metamorth.Helpers.Q
+import Metamorth.Helpers.State
 
 import Metamorth.ForOutput.Quasi.Types
 
@@ -58,12 +59,15 @@ makeTheDecs str = do
           (errs,wrns,_mmsgs) =  partitionMessages msgs
       mapM_ reportError   errs
       mapM_ reportWarning wrns
-      let ((irslts',orslts'), descMap) = flip State.runState M.empty $ fmap unzip $ forM ods $ \od -> case (odInputFile od, odOutputFile od) of
-            (Nothing, Nothing) -> return (Nothing, Nothing)
+      let ((irslts',orslts' {- , cmdNoms' -}), descMap) = stateRun M.empty $ fmap unzip $ forM ods $ \od -> case (odInputFile od, odOutputFile od) of
+            (Nothing, Nothing) -> return (Nothing, Nothing) -- , Nothing)
             (Just inFile, Just outFile) -> do
+              -- Run a state action to add the description of the orthography
+              -- to the description dictionary (which is the state value).
               case (odCLINames od, odDescription od) of
                 (nom:_, Just desc) -> State.modify' (M.insert nom desc)
                 _ -> return ()
+              -- 
               return
                 ( Just (inFile, ExtraParserDetails 
                    { epdParserName = fromMaybe "whoops" $ odInputName od
@@ -77,10 +81,11 @@ makeTheDecs str = do
                    })
                 , Just (outFile, ExtraOutputDetails
                    { eodOutputName = fromMaybe "whoopsOut" $ odOutputName od
-                   , eodSuffix     = fromMaybe "_xo"       $ odOutSuffix od
-                   , eodExtension  = fromMaybe ".op"       $ odExtension od
+                   , eodSuffix     = fromMaybe "_xo"       $ odOutSuffix  od
+                   , eodExtension  = fromMaybe ".op"       $ odExtension  od
                    , eodOtherNames = odCLINames od
                    })
+                -- , Just (odCLINames od)
                 )
             (Just inFile, Nothing) -> do
               case (odCLINames od, odDescription od) of
@@ -97,6 +102,7 @@ makeTheDecs str = do
                    , epdMainFuncName  = "theActualParser"
                    })
                 , Nothing
+                -- , Just (odCLINames od)
                 )
             (Nothing, Just outFile) -> do 
               case (odCLINames od, odDescription od) of
@@ -110,9 +116,11 @@ makeTheDecs str = do
                    , eodExtension  = fromMaybe ".op"       $ odExtension od
                    , eodOtherNames = odCLINames od
                    })
+                -- , Just (odCLINames od)
                 )
           irslts = catMaybes irslts'
           orslts = catMaybes orslts'
+          -- cmdNoms = catMaybes cmdNoms'
       when (null irslts) $ reportWarning  "No input specification files listed."
       when (null orslts) $ reportWarning "No output specification files listed."
       -- qDebugNotice $ "Phoneme path: \"" ++ pfp ++ "\"."

--- a/src/Metamorth/Interaction/TH.hs
+++ b/src/Metamorth/Interaction/TH.hs
@@ -30,6 +30,8 @@ import Data.Set        qualified as S
 
 import Data.ByteString.Lazy qualified as BL
 
+import Data.String (IsString)
+
 import Data.Text              qualified as T
 import Data.Text.Lazy         qualified as TL
 import Data.Text.Lazy.Builder qualified as TB
@@ -90,6 +92,9 @@ import THLego.Helpers
 
 import Metamorth.ForOutput.Functor.Cased
 
+-- CasedWord can be found at
+-- fst $ pdbWordTypeNames pdb
+
 -- | Simple type for the output of the generated
 --   declarations.
 data GeneratedDecs = GeneratedDecs
@@ -103,6 +108,7 @@ data GeneratedDecs = GeneratedDecs
   , gdOutputTypesBS :: M.Map Name Name
   , gdInputMap      :: [Dec]
   , gdOutputMap     :: [Dec]
+  , gdWordType      :: Name
   } deriving (Show, Eq)
 
 -- | Options to go along with each parser file.
@@ -196,7 +202,7 @@ declareParsers fp1 fps2 fps3 = do
   -- Maybe this will help?
   let allFps = fp1 : (map fst fps2) ++ (map fst fps3)
   mapM_ addLocalDependentFile' allFps
-  (GeneratedDecs d1 ds2 ds3 ds4 (iNom, oNom) inMap outMap outMapBS inMapDec outMapDec) <- createParsers fp1 fps2 fps3
+  (GeneratedDecs d1 ds2 ds3 ds4 (iNom, oNom) inMap outMap outMapBS inMapDec outMapDec cwdName) <- createParsers fp1 fps2 fps3
   
   -- Create the full function...
   -- funcDecs <- makeFullFunction iNom oNom inMap outMap
@@ -219,10 +225,10 @@ declareFullParsersNew isCas fp1 fps2 fps3 = do
   -- Maybe this will help?
   let allFps = fp1 : (map fst fps2) ++ (map fst fps3)
   mapM_ addLocalDependentFile' allFps
-  (GeneratedDecs d1 ds2 ds3 ds4 (iNom, oNom) inMap outMap outMapBS inMapDec outMapDec) <- createParsersNew isCas fp1 fps2 fps3
+  (GeneratedDecs d1 ds2 ds3 ds4 (iNom, oNom) inMap outMap outMapBS inMapDec outMapDec cwdName) <- createParsersNew isCas fp1 fps2 fps3
   
   -- Create the full function...
-  funcDecs <- makeFullFunction iNom oNom inMap outMap outMapBS
+  funcDecs <- makeFullFunction iNom oNom inMap outMap outMapBS cwdName
 
   return (funcDecs ++ ds4 ++ d1 ++ (concat ds2) ++ (concat ds3) ++ inMapDec ++ outMapDec)
 
@@ -344,6 +350,7 @@ createParsersNew canBeCased phonemePath parserPaths outputPaths = do
              outOrthMapBS
              inputOrthNameDecl
              outputOrthNameDecl
+             (fst (pdbWordTypeNames pdb))
 
 readPhonemeFile :: FilePath -> IO (Either String Text)
 readPhonemeFile fp = do
@@ -512,8 +519,11 @@ makeInputOrthType mps = do
 
 -- | Make the full function that can easily
 --   be called by a CLI application.
-makeFullFunction :: forall q. (Quote q, Quasi q) => Name -> Name -> M.Map Name Name -> M.Map Name Name -> M.Map Name Name -> q [Dec]
-makeFullFunction iNom oNom inNames outNames outNamesBS = do 
+--
+--   Also: makes the "Half functions" that
+--   only parse the text or output the text.
+makeFullFunction :: forall q. (Quote q, Quasi q) => Name -> Name -> M.Map Name Name -> M.Map Name Name -> M.Map Name Name -> Name -> q [Dec]
+makeFullFunction iNom oNom inNames outNames outNamesBS cwdName = do 
   funcName <- newName "convertOrthography"
   funcType <- [t| $(pure $ ConT iNom) -> $(pure $ ConT oNom) -> Text -> Either String Text |]
   funcSign <- return $ SigD funcName funcType
@@ -525,7 +535,16 @@ makeFullFunction iNom oNom inNames outNames outNamesBS = do
   funcNameBS <- newName "convertOrthographyBS"
   funcTypeBS <- [t| $(pure $ ConT iNom) -> $(pure $ ConT oNom) -> Text -> Either String BL.ByteString |]
   funcSignBS <- return $ SigD funcNameBS funcTypeBS
-  
+
+  -- Need to find where "CasedWord" is stored...
+  funcNamePrs <- newName "parseOrthography"
+  funcTypePrs <- [t| $(pure $ ConT iNom) -> AT.Parser [$(pure $ ConT cwdName)] |]
+  funcSignPrs <- return $ SigD funcNamePrs funcTypePrs
+
+  funcNameOut <- newName "emitOrthography"
+  funcTypeOut <- [t| forall str. (Monoid str, IsString str) => $(pure $ ConT oNom) -> (T.Text -> str) -> [$(pure $ ConT cwdName)] -> Either String str |]
+  funcSignOut <- return $ SigD funcNameOut funcTypeOut
+
   -- For the functions that select the input/output
   -- function to use based on the selector type.
   tempNameI <- newName "selectI"
@@ -533,7 +552,11 @@ makeFullFunction iNom oNom inNames outNames outNamesBS = do
   tempNameL <- newName "selectOL"
   tempNameB <- newName "selectBS"
 
+  tempNameI2 <- newName "selectI2"
+  tempNameO2 <- newName "selectO2"
+
   extraName1 <- newName "abc"
+  extraName2 <- newName "bcd"
 
   -- Too lazy to fill out the type signature...
   tempTypeI <- [t| $(pure $ ConT iNom) -> Text -> Either String _   |]
@@ -550,6 +573,11 @@ makeFullFunction iNom oNom inNames outNames outNamesBS = do
       tempFuncL = FunD tempNameL tempDefnL
       tempFuncB = FunD tempNameB tempDefnB
 
+      -- These aren't even the temporary definitions; these
+      -- are the definitions themselves.
+      tempDefnI2 = M.elems $ M.mapWithKey makeClauseI2 inNames
+      tempDefnO2 = M.elems $ M.mapWithKey (makeClauseO2 extraName1 extraName2) outNames
+
       tempSignI = SigD tempNameI tempTypeI
       tempSignO = SigD tempNameO tempTypeO
 
@@ -557,6 +585,7 @@ makeFullFunction iNom oNom inNames outNames outNamesBS = do
       whereDecs  = [tempFuncI, tempFuncO]
       whereDecsL = [tempFuncI, tempFuncL]
       whereDecsB = [tempFuncI, tempFuncB]
+
   
   when (M.null  inNames) $ qReportWarning  "There are no Input Orthography Names"
   when (M.null outNames) $ qReportWarning "There are no Output Orthography Names"
@@ -591,9 +620,22 @@ makeFullFunction iNom oNom inNames outNames outNamesBS = do
             (NormalB funcExpB)
             whereDecsB
         ]
-
+      
+      halfFuncParse = FunD funcNamePrs tempDefnI2
+      halfFuncEmit  = FunD funcNameOut tempDefnO2
   
-  return [funcSign, mainFuncDefn, funcSignL, mainFuncDefnLazy, funcSignBS, mainFuncDefnBS]
+  return 
+    [ funcSign
+    , mainFuncDefn
+    , funcSignL
+    , mainFuncDefnLazy
+    , funcSignBS
+    , mainFuncDefnBS
+    , funcSignPrs
+    , halfFuncParse
+    , funcSignOut
+    , halfFuncEmit
+    ]
   where
     makeClauseO :: Name -> Name -> Clause
     makeClauseO dNom fNom = Clause [ConP dNom [] []] (NormalB (AppE (VarE fNom) (VarE 'id))) []
@@ -611,8 +653,22 @@ makeFullFunction iNom oNom inNames outNames outNamesBS = do
       (NormalB $ VarE fNom)
       []
 
+    -- Running `AT.parseOnly` on the selected parser.
     makeClauseI :: Name -> Name -> Clause
     makeClauseI dnom fNom = Clause [ConP dnom [] []] (NormalB (AppE (VarE 'AT.parseOnly) (VarE fNom))) []
+
+    -- Just returning the parser itself.
+    makeClauseI2 :: Name -> Name -> Clause
+    makeClauseI2 dNom fNom = Clause [ConP dNom [] []] (NormalB (VarE fNom)) []
+
+    -- Returning the clause that returns the plain
+    -- "orthOutput" function, depending on the orthography.
+    makeClauseO2 :: Name -> Name -> Name -> Name -> Clause
+    makeClauseO2 cvtNom txtNom dNom fNom 
+      = Clause 
+          [ConP dNom [] [], VarP cvtNom, VarP txtNom] 
+          (NormalB $ multiAppE (VarE fNom) [VarE cvtNom, VarE txtNom]) 
+          []
 
     pve :: Name -> q Exp
     pve = pure . VarE 

--- a/src/Metamorth/Interpretation/Output/Parsing.hs
+++ b/src/Metamorth/Interpretation/Output/Parsing.hs
@@ -39,6 +39,7 @@ import Metamorth.Helpers.List
 import Metamorth.Helpers.Parsing
 import Metamorth.Helpers.Error ( ParserMessage )
 import Metamorth.Helpers.Error.RWS
+import Metamorth.Helpers.RWS
 
 import Metamorth.Interpretation.Output.Parsing.Trie
 import Metamorth.Interpretation.Output.Parsing.Types
@@ -99,6 +100,7 @@ parseOutputFile grps trts asps phones = do
         , opoTraitDictionary  = opsTraitDictionary ops
         , opoGroupDictionary  = opsGroupDictionary ops
         , opoAspectDictionary = opsAspectDictionary ops
+        , opoAddSpaces        = opsAddSpaces ops
         , opoOutputTrie = opsOutputTrie ops
         }
   -- Process the auto-states for the opo.
@@ -158,7 +160,7 @@ parseStateDecSection = do
   -- lift AT.skipSpace
   _ <- lift $ many parseEndComment
   many'_ $ do
-    getImportS_ <|> parseStateDecS -- <|> parseUnspecifiedClassOrState
+    getImportS_ <|> parseStateDecS <|> getPhoneSpacesS -- <|> parseUnspecifiedClassOrState
     lift $ AT.many1 parseEndComment
   _ <- lift $ many  parseEndComment
   _ <- lift ("====" <?> "States: Separator1")
@@ -252,6 +254,21 @@ getImportS = do
 --   that it is a valid import.
 getImportS_ :: OutputParser ()
 getImportS_ = void getImportS
+
+getPhoneSpaces :: AT.Parser Bool
+getPhoneSpaces = do
+  _ <- "add"
+  _ <- (void $ AT.char '_') <|> skipHoriz
+  _ <- "spaces"
+  return True
+
+-- | When this parser succeeds, it
+--   means the outputter should add
+--   spaces at the end of ouput patterns.
+getPhoneSpacesS :: OutputParser ()
+getPhoneSpacesS = do
+  bl <- lift getPhoneSpaces
+  modify' $ \x -> x {opsAddSpaces = bl}
 
 -- | Import a trait/group/aspect from the phoneme file.
 --   Moved to Metamorth.Interpretation.Shared.Types

--- a/src/Metamorth/Interpretation/Output/Parsing.hs
+++ b/src/Metamorth/Interpretation/Output/Parsing.hs
@@ -962,8 +962,9 @@ parsePhonemePatMulti' = do
         (Left  errs) -> do 
           mkErrors $ map (\err -> "Error with phoneme pattern for \"" ++ phoneName ++ "\": " ++ err) [errs]
           return ([], OutputPattern (CharPattern (CaseRegular []) []) OCNull)
-        (Right phonePats) -> -- addPhonemesPattern phones rslt
-          case (validateCharPattern sdict thePats) of
+        (Right phonePats) -> do -- addPhonemesPattern phones rslt
+          vldRslt <- validateCharPatternX sdict thePats
+          case vldRslt of
             (Left  errs) -> do 
               mkErrors $ map (\err -> "Error with output pattern for \"" ++ phoneName ++ "\": " ++ err) [errs]
               return ([], OutputPattern (CharPattern (CaseRegular []) []) OCNull)
@@ -977,13 +978,27 @@ parsePhonemePatMulti' = do
         (Left  errs) -> do 
           mkErrors $ map (\err -> "Error with phoneme pattern for \"" ++ phoneName ++ "\": " ++ err) [errs]
           return ([], OutputPattern (CharPattern (CaseSeparate [] []) []) OCNull)
-        (Right phonePats) -> -- addPhonemesPattern phones rslt
-          case (validateCharPattern2 sdict pats1 pats2) of
+        (Right phonePats) -> do -- addPhonemesPattern phones rslt
+          vldRslt <- validateCharPattern2X sdict pats1 pats2
+          case vldRslt of
             (Left  errs) -> do 
               mkErrors $ map (\err -> "Error with output pattern for \"" ++ phoneName ++ "\": " ++ err) [errs]
               return ([], OutputPattern (CharPattern (CaseRegular []) []) OCNull)
             (Right cPats) -> return (phonePats, OutputPattern cPats theCase)
 
+validateCharPatternX :: M.Map String (Maybe (S.Set String)) -> [CharPatternRaw] -> OutputParser (Either String CharPattern)
+validateCharPatternX sdict pats = do
+  addSpaces <- gets opsAddSpaces
+  if addSpaces
+    then return (validateCharPatternS sdict pats)
+    else return (validateCharPattern  sdict pats)
+
+validateCharPattern2X :: M.Map String (Maybe (S.Set String)) -> [CharPatternRaw] -> [CharPatternRaw] -> OutputParser (Either String CharPattern)
+validateCharPattern2X sdict p1 p2 = do
+  addSpaces <- gets opsAddSpaces
+  if addSpaces
+    then return (validateCharPattern2S sdict p1 p2)
+    else return (validateCharPattern2  sdict p1 p2)
 
 {-
 data CharPattern = CharPattern

--- a/src/Metamorth/Interpretation/Output/Parsing/Types.hs
+++ b/src/Metamorth/Interpretation/Output/Parsing/Types.hs
@@ -10,7 +10,9 @@ module Metamorth.Interpretation.Output.Parsing.Types
   , runOnPhoneme
   , CharPatternRaw(..)
   , validateCharPattern
+  , validateCharPatternS
   , validateCharPattern2
+  , validateCharPattern2S
   , ImportProperty(..)
   , PhoneName(..)
   , PhonePatternRaw(..)
@@ -338,6 +340,13 @@ validateCharPattern mp cps = do
   sts' <- traverse (validateModifyState mp) sts
   return $ CharPattern (CaseRegular itms) sts'
 
+validateCharPatternS :: M.Map String (Maybe (S.Set String)) -> [CharPatternRaw] -> Either String CharPattern
+validateCharPatternS mp cps = do
+  let (sts, rst) = partitionMaybe getPlainState cps
+      itms       = mapMaybe getPlainChar rst
+  sts' <- traverse (validateModifyState mp) sts
+  return $ CharPattern (CaseRegular (itms ++ [UncasableChar ' '])) sts'
+
 validateCharPattern2 :: M.Map String (Maybe (S.Set String)) -> [CharPatternRaw] -> [CharPatternRaw] -> Either String CharPattern
 validateCharPattern2 mp cps1 cps2 = do
   let (sts1, rst1) = partitionMaybe getPlainState cps1
@@ -347,4 +356,16 @@ validateCharPattern2 mp cps1 cps2 = do
       sts          = nubSort (sts1 ++ sts2)
   sts' <- traverse (validateModifyState mp) sts
   return $ CharPattern (CaseSeparate itms1 itms2) sts'
+
+-- | Like validateCharPattern2, but adds a space 
+--   at the end of each pattern.
+validateCharPattern2S :: M.Map String (Maybe (S.Set String)) -> [CharPatternRaw] -> [CharPatternRaw] -> Either String CharPattern
+validateCharPattern2S mp cps1 cps2 = do
+  let (sts1, rst1) = partitionMaybe getPlainState cps1
+      (sts2, rst2) = partitionMaybe getPlainState cps2
+      itms1        = mapMaybe getFreeChar rst1
+      itms2        = mapMaybe getFreeChar rst2
+      sts          = nubSort (sts1 ++ sts2)
+  sts' <- traverse (validateModifyState mp) sts
+  return $ CharPattern (CaseSeparate (itms1 ++ " ") (itms2 ++ " ")) sts'
 

--- a/src/Metamorth/Interpretation/Output/Parsing/Types.hs
+++ b/src/Metamorth/Interpretation/Output/Parsing/Types.hs
@@ -79,6 +79,7 @@ embedOutputParser grps trts asps phons prs
       , opsAspectDictionary' = asps
       , opsPhoneDictionary   = phons
       , opsDefaultCasing     = OCNull
+      , opsAddSpaces         = False
       , opsOutputTrie        = TM.empty
       }
 
@@ -95,6 +96,7 @@ testOutputParser1 prs = AT.parseOnly (runRWST prs "N/A" st)
         , opsAspectDictionary' = M.empty
         , opsPhoneDictionary   = S.empty
         , opsDefaultCasing     = OCNull
+        , opsAddSpaces         = False
         , opsOutputTrie        = TM.empty
         }
 
@@ -134,6 +136,10 @@ data OutputParsingState = OutputParsingState
   --   by the parser.
   , opsPhoneDictionary :: S.Set String
   , opsDefaultCasing   :: OutputCase
+  -- | Whether to add spaces after each output pattern.
+  --   Useful when outputting data that requires spaces
+  --   between phonemes.
+  , opsAddSpaces       :: Bool
   -- | The main trie to be used for determining
   --   output.
   , opsOutputTrie      :: TM.TMap PhonePatternAlt (S.Set PhoneResult)

--- a/src/Metamorth/Interpretation/Output/Types/Alt.hs
+++ b/src/Metamorth/Interpretation/Output/Types/Alt.hs
@@ -242,6 +242,10 @@ data OutputParserOutput = OutputParserOutput
   --   are run. The `S.Set` contains the possible
   --   values for the trait.
   , opoAspectDictionary :: M.Map String (S.Set String)
+  -- | Whether to automatically add spaces after each
+  --   letter. This is useful when converting text to
+  --   lists of phonemes.
+     , opoAddSpaces        :: Bool
   -- | The main trie to be used for determining
   --   output.
   , opoOutputTrie       :: TM.TMap PhonePatternAlt (S.Set PhoneResult)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -186,6 +186,12 @@ main = do
     (Left err) -> putStrLn $ "Error: " ++ err
     (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
 
+  putStrLn "Testing MFA Output..."
+  let mfa1 = TLE.decodeUtf8 <$> KwakQ.convertOrthographyBS KwakQ.InGrubb KwakQ.OutMFA mfaTest1
+  case mfa1 of
+    (Left err) -> putStrLn $ "Error: " ++ err
+    (Right tx) -> hPutStrLnUtf8 stdout (toStrict tx)
+
 
 -- | From the Inuktitut Wikipedia page for Inuktitut.
 exampleText :: T.Text
@@ -234,6 +240,9 @@ caseTest1 = "Ehtla eHtlA"
 
 caseTest2 :: T.Text
 caseTest2 = "Iga iga oga"
+
+mfaTest1 :: T.Text
+mfaTest1 = "Kwak'wala"
 
 {-
    b : example=exam1

--- a/test/Test/TH/KwakQuasi.hs
+++ b/test/Test/TH/KwakQuasi.hs
@@ -64,6 +64,12 @@ Boas
   unify-branches : off
   description : "Collection of Boas's orthographies."
 
+MFA
+  output : "examples/output/kwakwala_mfa.thyo"
+  suffix : "_mfa"
+  output-name : "mfaOutput"
+  extension : ".mfa"
+
 |]
 
 {-

--- a/test/Test/TH/KwakQuasi.hs
+++ b/test/Test/TH/KwakQuasi.hs
@@ -15,6 +15,8 @@ module Test.TH.KwakQuasi
   , OutOrth(..)
   , inputOrthNameMap
   , outputOrthNameMap
+  , parseOrthography
+  , emitOrthography
   ) where
 
 import Metamorth.Interaction.Quasi


### PR DESCRIPTION
This PR adds a couple features that'll make it easier to generate pronunciation dictionaries for the [Montreal Forced Aligner](https://montreal-forced-aligner.readthedocs.io/en/latest/).

First, it adds the simple `add_spaces` option to output specifications. If you add the string `add_spaces` (or `add spaces`) to a line in the state/import section, it'll automatically add a space to the end of each output pattern. This is useful for generating wordlist dictionaries where one side has a space between each phoneme. Note that if one internal `Phoneme` technically corresponds to two phonemes for the dictionary, you'll have to manually add a space between phonemes in the appropriate output pattern.

The second feature is that using the `metamorth` quasi-quoter now adds a couple more functions you can add to the output list. They are `parseOrthography` and `emitOrthography`. These are essentially "half functions" that perform one half of the current `convertOrthography` family of functions. 

The types of these functions are:

```haskell
parseOrthography :: InOrth -> Parser [CasedWord]
emitOrthography  :: forall str. (IsString str, Monoid str) => OutOrth -> (Text -> str) -> [CasedWord] -> Either String str
```

These functions are useful when you want to parse once, but output twice. For example, let's say you want to take a text in one orthography, and convert it to multiple orthographies without re-parsing it each time. You can just run:

```haskell
import Data.Attoparsec.Text qualified as AT
import Data.Text qualified as T

writeMulti :: T.Text -> Either String (T.Text, T.Text, T.Text)
writeMulti txt = do
  wds  <- AT.parseOnly (parseOrthography InOrth1)
  out1 <- emitOrthography OutOrth1 id wds
  out2 <- emitOrthography OutOrth2 id wds
  out3 <- emitOrthography OutOrth3 id wds
  return (out1, out2, out3)
```

...with more complicated usage (especially using `lines`, `unlines`, and `zipWith`), you can make a dictionary this way.